### PR TITLE
update legacy bcs path

### DIFF
--- a/plots/configure
+++ b/plots/configure
@@ -32,7 +32,7 @@ if( $arch == 'Linux'    ) then
                               setenv PATH         ${PATH}:${ImagMag_bin}
                               set    path =     ( ${path} ${ImagMag_bin} )
     else if( $host == 'discover' ) then
-                              setenv TOPODIR      /discover/nobackup/ltakacs/bcs/Ganymed-4_0/TOPO
+                              setenv TOPODIR      /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Ganymed-4_0/TOPO
                               setenv NCCS_SHARE   ${SHARE}/gmao_ops/
                               setenv VERIFICATION ${NCCS_SHARE}/verification
                               setenv OPENGADIR    ${SHARE}/gmao_ops/opengrads/Contents

--- a/post/ec_prs2fv
+++ b/post/ec_prs2fv
@@ -14,7 +14,7 @@ set ydim = 721
 
 set dynrst = `ls *fvcore_internal_rst.${nymd}_${hour}z.*`
 set mstrst = `ls *moist_internal_rst.${nymd}_${hour}z.*`
-set topo   = /discover/nobackup/ltakacs/bcs/Fortuna-2_1/${xdim}x${ydim}/topo_DYN_ave_${xdim}x${ydim}_DC.data
+set topo   = /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Fortuna-2_1/${xdim}x${ydim}/topo_DYN_ave_${xdim}x${ydim}_DC.data
 
 
 # Link Original ECMWF.nc File

--- a/post/tests/amip_c180Toc90.yaml
+++ b/post/tests/amip_c180Toc90.yaml
@@ -10,7 +10,7 @@ input:
   shared:
     MERRA-2: false
     agrid: C180
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
+    bcs_dir: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
     expid: JM_v10.22.2_L072_C180_AMIP
     ogrid: 1440X720
     rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/amip_c180Toc90/inputs/
@@ -24,7 +24,7 @@ input:
 output:
   shared:
     agrid: C90
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0090x6C_CF0090x6C/
+    bcs_dir: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0090x6C_CF0090x6C/
     expid: C90CS_JM_v10.22.2_L072_C180_AMIP
     ogrid: C90
     out_dir: $NOBACKUP/REMAP_TESTS/amip_c180Toc90/

--- a/post/tests/c180Toc360.yaml
+++ b/post/tests/c180Toc360.yaml
@@ -10,7 +10,7 @@ input:
   shared:
     MERRA-2: false
     agrid: C180
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
+    bcs_dir: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
     expid: Jason-3_4_NL_REAMIP_MERRA2_C180
     ogrid: 1440X720
     rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c180Toc360/inputs/
@@ -24,7 +24,7 @@ input:
 output:
   shared:
     agrid: C360
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0360x6C_CF0360x6C/
+    bcs_dir: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0360x6C_CF0360x6C/
     expid: C360CS_Jason-3_4_NL_REAMIP_MERRA2_C180
     ogrid: C360
     out_dir: $NOBACKUP/REMAP_TESTS/c360Toc24/

--- a/post/tests/c360Toc24.yaml
+++ b/post/tests/c360Toc24.yaml
@@ -24,7 +24,7 @@ input:
 output:
   shared:
     agrid: C24
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_Reynolds//CF0024x6C_DE0360xPE0180/
+    bcs_dir: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus-NLv3/Icarus-NLv3_Reynolds//CF0024x6C_DE0360xPE0180/
     expid: C24c_x0046a
     ogrid: 360X180
     out_dir: $NOBACKUP/REMAP_TESTS/c360Toc24/

--- a/pre/NSIDC-OSTIA_SST-ICE_blend/cube_BCs.pl
+++ b/pre/NSIDC-OSTIA_SST-ICE_blend/cube_BCs.pl
@@ -26,7 +26,7 @@ my ($outdir, $gid, $workarea, $noprompt);
 my ($yyyy, %oResVals, %varVals, $workdir);
 my ($tiledir, $bcsdir, %variables, %resolutions);
 
-$tiledir = "/discover/nobackup/ltakacs/bcs/Icarus/Shared";
+$tiledir = "/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs/Icarus/Shared";
 
 $bcsdir = "/discover/nobackup/projects/gmao/share/dao_ops/fvInput/"
     .      "g5gcm/bcs/realtime/OSTIA_REYNOLDS/2880x1440";


### PR DESCRIPTION
This PR updates the path to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space on Discover (replacing /discover/nobackup/ltakacs/bcs/ )

This is the first step in using (legacy) bcs from the new "bcs_shared" dir.