### PR TITLE
Support for new bcs output layout 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updates paths to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space.
+- Support for new boundary conditions package output layout
 
 ### Fixed
 

--- a/pre/remap_restart/remap_analysis.py
+++ b/pre/remap_restart/remap_analysis.py
@@ -35,8 +35,6 @@ class analysis(remap_base):
 
      cwdir  = os.getcwd()
      bindir = os.path.dirname(os.path.realpath(__file__))
-     in_bcsdir  = config['input']['shared']['bcs_dir']
-     out_bcsdir = config['output']['shared']['bcs_dir']
      out_dir    = config['output']['shared']['out_dir']
      if not os.path.exists(out_dir) : os.makedirs(out_dir)
      print( "cd " + out_dir)

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -13,8 +13,8 @@ def get_landdir(bcsdir):
   k = bcsdir.find('/geometry/')
   if k != -1 :
      while bcsdir[-1] == '/': bcsdir = bcsdir[0:-1] # remove extra '/'
-     agrid_name = os.path.basename(bcsdir).split('_')[0]
-     bcsdir = bcsdir[0:k]+'/land/'+agrid_name
+     sub_grids = os.path.basename(bcsdir)
+     bcsdir = bcsdir[0:k]+'/land/'+ sub_grids 
   return bcsdir
 
 class catchANDcn(remap_base):

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -9,6 +9,14 @@ import ruamel.yaml
 import shlex
 from remap_base import remap_base
 
+def get_landdir(bcsdir):
+  k = bcsdir.find('/geometry/')
+  if k != -1 :
+     while bcsdir[-1] == '/': bcsdir = bcsdir[0:-1] # remove extra '/'
+     agrid_name = os.path.basename(bcsdir).split('_')[0]
+     bcsdir = bcsdir[0:k]+'/land/'+agrid_name
+  return bcsdir
+
 class catchANDcn(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
@@ -75,6 +83,7 @@ class catchANDcn(remap_base):
      shutil.copyfile(in_rstfile,dest)
      in_rstfile = dest
 
+     out_bcsdir = get_landdir(out_bcsdir)
      log_name = out_dir+'/'+'mk_catchANDcn_log'
      mk_catch_j_template = """#!/bin/csh -f
 #SBATCH --account={account}

--- a/pre/remap_restart/remap_params.py
+++ b/pre/remap_restart/remap_params.py
@@ -225,7 +225,7 @@ class remap_params(object):
 
      self.bcbase={}
      self.bcbase['discover_ops'] = "/discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs"
-     self.bcbase['discover_lt']  = "/discover/nobackup/ltakacs/bcs"
+     self.bcbase['discover_legacy']  = "/discover/nobackup/projects/gmao/bcs_shared/legacy_bcs"
      self.bcbase['discover_couple']  = "/discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs"
      self.bcbase['discover_ns']  = "/discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles"
 
@@ -269,8 +269,8 @@ class remap_params(object):
            return self.bcbase[base]
         if model == 'MOM6' or model == 'MOM5':
           base = 'discover_couple'
-     assert base, 'please specify bc_base: discover_ops, discover_lt, discover_couple or an absolute path'
-     if base == 'discover_ops' or base == 'discover_lt' or base=='discover_couple':
+     assert base, 'please specify bc_base: discover_ops, discover_legacy, discover_couple or an absolute path'
+     if base == 'discover_ops' or base == 'discover_legacy' or base=='discover_couple':
         return self.bcbase[base]
      else:
         return base 

--- a/pre/remap_restart/remap_params.py
+++ b/pre/remap_restart/remap_params.py
@@ -221,7 +221,7 @@ class remap_params(object):
      self.tagsRank['Icarus-NLv3_Reynolds'] = 18
      self.tagsRank['Icarus-NLv3_MERRA-2']  = 19
      self.tagsRank['Icarus-NLv3_Ostia']    = 20
-     for tag in newStructure: self.tagsRank[tag] = 21
+     for tag in self.newStructure: self.tagsRank[tag] = 21
 
      self.bcbase={}
      self.bcbase['discover_ops'] = "/discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs"

--- a/pre/remap_restart/remap_params.py
+++ b/pre/remap_restart/remap_params.py
@@ -372,26 +372,21 @@ class remap_params(object):
      if len(gridID) == 0 :
        exit("cannot find the grid subdirctory of agrid: " +agrid_+ " and ogrid " + ogrid_ + " under "+ bcdir)
      g = ''
-     if len(gridID) == 1 : g = gridID[0]
+     gridID.sort(key=len)
+     g = gridID[0]
 
-     if len(gridID) == 2 :
-        print(" gridIDs found", gridID)
-        assert omodel_ == 'MOM5' or omodel_ == 'MOM6', "found two subdirestories"
-        for g_ in gridID :
-          if omodel_ == 'MOM5':
-             if '_M5_' in g_ : g = g_
-          if omodel_ == 'MOM6':
-             if '_M6_' in g_ : g = g_
+     # For new structure BC
+     for g_ in gridID :
+       if omodel_ == 'MOM5':
+          if '_M5_' in g_ : g = g_
+       if omodel_ == 'MOM6':
+          if '_M6_' in g_ : g = g_
 
-     if len(gridID) >= 3 :
-        print("find too many grid strings in " + bcdir)
-        print(" gridIDs found", gridID)
-        for g_ in gridID:
-          if g_.count('_') == 1 :
-            g = g_ 
-            #WY note, found many string in the directory
-            print(" pick the first directory with only one '_' " + g)
-            break
+     if len(gridID) >= 2 :
+        print("\n Warning! Find many GridIDs in " + bcdir)
+        print(" GridIDs found: ", gridID)
+        #WY note, found many string in the directory
+        print(" This GridID is chosen: " + g)
      return g
 
   def get_bcTag(self, tag, ogrid):

--- a/pre/remap_restart/remap_params.py
+++ b/pre/remap_restart/remap_params.py
@@ -171,6 +171,7 @@ class remap_params(object):
      GITNL = ( 'GITNL', '10.19', '10.20', '10.21', '10.22', '10.23' )
      D525  = ( '525', 'GEOSadas-5_25_1', 'GEOSadas-5_25_1_p5', 'GEOSadas-5_25_p7',
                       'GEOSadas-5_27_1', 'GEOSadas-5_29_3',    'GEOSadas-5_29_4' )
+     self.newStructure = ('NL3', 'NL4', 'NL5', 'NL6', 'NL7', 'NL8', 'NL9')
 
      self.bcsTag={}
      for tag in F14:   self.bcsTag[tag]= "Fortuna-1_4"
@@ -185,6 +186,7 @@ class remap_params(object):
      for tag in GITOL: self.bcsTag[tag]= "Icarus_Reynolds"
      for tag in INL:   self.bcsTag[tag]= "Icarus-NLv3_Reynolds"
      for tag in GITNL: self.bcsTag[tag]= "Icarus-NLv3_Reynolds"
+     for tag in self.newStructure: self.bcsTag[tag]= tag
 
      
      for tag in D214:  self.bcsTag[tag]= "Fortuna-1_4"
@@ -219,11 +221,13 @@ class remap_params(object):
      self.tagsRank['Icarus-NLv3_Reynolds'] = 18
      self.tagsRank['Icarus-NLv3_MERRA-2']  = 19
      self.tagsRank['Icarus-NLv3_Ostia']    = 20
+     for tag in newStructure: self.tagsRank[tag] = 21
 
      self.bcbase={}
      self.bcbase['discover_ops'] = "/discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs"
      self.bcbase['discover_lt']  = "/discover/nobackup/ltakacs/bcs"
      self.bcbase['discover_couple']  = "/discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs"
+     self.bcbase['discover_ns']  = "/discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles"
 
   def init_time(self):
      ymdh = self.common_in.get('yyyymmddhh')
@@ -251,17 +255,20 @@ class remap_params(object):
      
      if opt.upper() == 'IN':
         model = self.common_in.get('model')
+        base  = self.common_in.get('bc_base')
+        if base == 'discover_ns':
+           return self.bcbase[base]
+           
         if model == 'MOM6' or model == 'MOM5':
           base = 'discover_couple'
-        else:
-          base  = self.common_in.get('bc_base')
 
      if opt.upper() == 'OUT':
         model = self.common_out.get('model')
+        base = self.common_out.get('bc_base')
+        if base == 'discover_ns':
+           return self.bcbase[base]
         if model == 'MOM6' or model == 'MOM5':
           base = 'discover_couple'
-        else:
-          base = self.common_out.get('bc_base')
      assert base, 'please specify bc_base: discover_ops, discover_lt, discover_couple or an absolute path'
      if base == 'discover_ops' or base == 'discover_lt' or base=='discover_couple':
         return self.bcbase[base]
@@ -283,7 +290,10 @@ class remap_params(object):
        bc_base = self.get_bcbase(opt)
        bctag = self.get_bcTag(tag,ogrid)
        tagrank = self.tagsRank[bctag]
-       if (tagrank >= self.tagsRank['Icarus-NLv3_Reynolds']) :
+
+       if (tagrank >= self.tagsRank['NL3']) :
+          bcdir = bc_base+'/'+ bctag+'/geometry/'
+       elif (tagrank >= self.tagsRank['Icarus-NLv3_Reynolds']) :
           bcdir = bc_base+'/Icarus-NLv3/'+bctag+'/'
           if model == 'MOM6' or model == 'MOM5':
              bcdir = bc_base+'/Icarus-NLv3/'+model+'/'
@@ -319,7 +329,7 @@ class remap_params(object):
        namex = []
        if (grid[0].upper() == 'C'):
          n = int(grid[1:])
-         s1 ='{n}x6C'.format(n=n)
+         s1 ='{:04d}x6C'.format(n)
          j=n*6
          s2 =str(n)
          s3 =str(j)
@@ -329,7 +339,7 @@ class remap_params(object):
            if(a_o == 'a'):
              name = aoname.split('_')[0]
            else:
-             name = aoname.split('_')[1]
+             name = aoname.split('_')[-1]
            if (name.find(s1) != -1 or (name.find(s2) != -1 and name.find(s3) != -1 )):
               namex.append(aoname)
        else:
@@ -341,18 +351,21 @@ class remap_params(object):
            if(a_o == 'a'):
              name = aoname.split('_')[0]
            else:
-             name = aoname.split('_')[1]
+             name = aoname.split('_')[-1]
            if (name.find(s2) != -1 and name.find(s3) != -1): namex.append(aoname)
        return namex
      #v3.5
      #dirnames = [ f.name for f in os.scandir(bcdir) if f.is_dir()]
      #v2.7
      dirnames = [f for f in os.listdir(bcdir) if os.path.isdir(os.path.join(bcdir,f))]
-     agrid_ = self.common_in['agrid']   
-     ogrid_ = self.common_in['ogrid'] 
+     
+     agrid_  = self.common_in['agrid']   
+     ogrid_  = self.common_in['ogrid'] 
+     omodel_ = self.common_in.get('model')
      if opt.upper() == "OUT" :
-       agrid_ = self.common_out['agrid']   
-       ogrid_ = self.common_out['ogrid'] 
+       agrid_  = self.common_out['agrid']   
+       ogrid_  = self.common_out['ogrid'] 
+       omodel_ = self.common_out.get('model')
           
      anames = get_name_with_grid(agrid_, dirnames, 'a')
      gridID = get_name_with_grid(ogrid_, anames, 'o')
@@ -360,19 +373,30 @@ class remap_params(object):
        exit("cannot find the grid subdirctory of agrid: " +agrid_+ " and ogrid " + ogrid_ + " under "+ bcdir)
      g = ''
      if len(gridID) == 1 : g = gridID[0]
-     if len(gridID) >=2 :
-       print("find too many grid strings in " + bcdir)
-       print(" gridIDs found", gridID)
-       for g_ in gridID:
-         if g_.count('_') == 1 :
-           g = g_ 
-           #WY note, found many string in couple model
-           print(" pick the first directory with only one '_' " + g)
-           break
+
+     if len(gridID) == 2 :
+        print(" gridIDs found", gridID)
+        assert omodel_ == 'MOM5' or omodel_ == 'MOM6', "found two subdirestories"
+        for g_ in gridID :
+          if omodel_ == 'MOM5':
+             if '_M5_' in g_ : g = g_
+          if omodel_ == 'MOM6':
+             if '_M6_' in g_ : g = g_
+
+     if len(gridID) >= 3 :
+        print("find too many grid strings in " + bcdir)
+        print(" gridIDs found", gridID)
+        for g_ in gridID:
+          if g_.count('_') == 1 :
+            g = g_ 
+            #WY note, found many string in the directory
+            print(" pick the first directory with only one '_' " + g)
+            break
      return g
 
   def get_bcTag(self, tag, ogrid):
     bctag = self.bcsTag[tag]
+    if bctag in self.newStructure : return bctag
     if ogrid[0].upper() == "C": 
        bctag=bctag.replace('_Reynolds','_Ostia')
     else:

--- a/pre/remap_restart/remap_params.py
+++ b/pre/remap_restart/remap_params.py
@@ -171,7 +171,7 @@ class remap_params(object):
      GITNL = ( 'GITNL', '10.19', '10.20', '10.21', '10.22', '10.23' )
      D525  = ( '525', 'GEOSadas-5_25_1', 'GEOSadas-5_25_1_p5', 'GEOSadas-5_25_p7',
                       'GEOSadas-5_27_1', 'GEOSadas-5_29_3',    'GEOSadas-5_29_4' )
-     self.newStructure = ('NL3', 'NL4', 'NL5', 'NL6', 'NL7', 'NL8', 'NL9')
+     self.newStructure = ('NL3', 'NL4', 'NL5', 'v06', 'v07', 'v08', 'v09')
 
      self.bcsTag={}
      for tag in F14:   self.bcsTag[tag]= "Fortuna-1_4"

--- a/pre/remap_restart/remap_questions.py
+++ b/pre/remap_restart/remap_questions.py
@@ -43,6 +43,7 @@ def data_ocean_default(resolution):
 def we_default(tag):
    default_ = '26'
    if tag in ['INL','GITNL', '525'] : default_ = '13'
+   if tag in ['NL3','NL4', 'NL5', 'NL6','NL6', 'NL6', 'NL9'] : default_ = '13'
    return default_
 
 def zoom_default(x):

--- a/pre/remap_restart/remap_questions.py
+++ b/pre/remap_restart/remap_questions.py
@@ -200,10 +200,15 @@ def ask_questions():
         },
 
         {
-            "type": "text",
-            "name": "input:shared:tag",
-            "message": "Enter GCM or DAS tag for input: \n \
-Sample GCM tags \n \
+            "type": "select",
+            "name": "input:shared:bc_base",
+            "message": "Select bcs base \n \
+             discover_ops: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs \n \
+             discover_lt: /discover/nobackup/ltakacs/bcs \n \
+             discover_couple: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs \n \
+             discover_ns: /discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles \n \
+\n \
+Sample GCM tags for discover_ops, discover_lt, discover_couple bc base :\n \
 --------------- \n \
 G40   : Ganymed-4_0  .........  Heracles-5_4_p3 \n \
 ICA   : Icarus  ..............  Jason \n \
@@ -211,32 +216,61 @@ GITOL : 10.3  ................  10.18 \n \
 INL   : Icarus-NL  ...........  Jason-NL \n \
 GITNL : 10.19  ...............  10.23 \n \
 \n \
-Sample DAS tags \n \
+Sample DAS tags for discover_ops, discover_lt, discover_couple bc base :\n \
 --------------- \n \
 5B0  : GEOSadas-5_10_0_p2  ..  GEOSadas-5_11_0 \n \
 512  : GEOSadas-5_12_2  .....  GEOSadas-5_16_5\n \
 517  : GEOSadas-5_17_0  .....  GEOSadas-5_24_0_p1\n \
-525  : GEOSadas-5_25_1  .....  GEOSadas-5_29_4\n",
-            "default": "INL",
-            "when": lambda x: not x["input:shared:MERRA-2"],
+525  : GEOSadas-5_25_1  .....  GEOSadas-5_29_4\n  \
+\n \
+Sample BC version for discover_ns ( new structure BC base): \n \
+-------------- \n \
+NL3   : Newland version 3 \n \
+NL4   : Newland version 4 \n \
+NL5   : Newland version 5 \n \
+NL6   : Not generated yet \n",
+            "choices": ["discover_ops", "discover_lt", "discover_couple","discover_ns", "other"],
+            "when": lambda x: not x['input:shared:MERRA-2'],
         },
+
+        {
+            "type": "text",
+            "name": "input:shared:tag",
+            "message": "Enter GCM or DAS tag for input:", 
+            "default": "INL",
+            "when": lambda x: not x["input:shared:MERRA-2"] and not x["input:shared:bc_base"]== "discover_ns",
+        },
+
+        {
+            "type": "text",
+            "name": "input:shared:tag",
+            "message": "Enter BC version for input:",
+            "default": "NL3",
+            "when": lambda x: not x["input:shared:MERRA-2"] and x["input:shared:bc_base"]== "discover_ns",
+        },
+
+        {
+            "type": "select",
+            "name": "output:shared:bc_base",
+            "message": "Select bcs base for new restarts:",
+            "choices": ["discover_ops", "discover_lt", "discover_couple","discover_ns", "other"],
+        },
+
         {
             "type": "text",
             "name": "output:shared:tag",
             "message": "Enter GCM or DAS tag for new restarts:",
             "default": "INL",
+            "when": lambda x:  not x["output:shared:bc_base"] == "discover_ns",
+        },
+        {
+            "type": "text",
+            "name": "output:shared:tag",
+            "message": "Enter BC version for new restarts:",
+            "default": "NL3",
+            "when": lambda x:  x["output:shared:bc_base"] == "discover_ns",
         },
 
-        {
-            "type": "select",
-            "name": "input:shared:bc_base",
-            "message": "Select bcs base \n \
-             discover_ops: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs \n \
-             discover_lt: /discover/nobackup/ltakacs/bcs \n \
-             discover_couple: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs \n",
-            "choices": ["discover_ops", "discover_lt", "discover_couple", "other"],
-            "when": lambda x: not x['input:shared:MERRA-2'],
-        },
         {
             "type": "path",
             "name": "input:shared:alt_bcs",
@@ -244,12 +278,6 @@ Sample DAS tags \n \
             "when": lambda x: x.get("input:shared:bc_base")=="other",
         },
 
-        {
-            "type": "select",
-            "name": "output:shared:bc_base",
-            "message": "Select bcs base for new restarts:",
-            "choices": ["discover_ops", "discover_lt", "discover_couple", "other"],
-        },
         {
             "type": "path",
             "name": "output:shared:alt_bcs",

--- a/pre/remap_restart/remap_questions.py
+++ b/pre/remap_restart/remap_questions.py
@@ -43,7 +43,7 @@ def data_ocean_default(resolution):
 def we_default(tag):
    default_ = '26'
    if tag in ['INL','GITNL', '525'] : default_ = '13'
-   if tag in ['NL3','NL4', 'NL5', 'NL6','NL6', 'NL6', 'NL9'] : default_ = '13'
+   if tag in ['NL3','NL4', 'NL5', 'v06','v07', 'v08', 'v09'] : default_ = '13'
    return default_
 
 def zoom_default(x):
@@ -205,11 +205,11 @@ def ask_questions():
             "name": "input:shared:bc_base",
             "message": "Select bcs base \n \
              discover_ops: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs \n \
-             discover_lt: /discover/nobackup/ltakacs/bcs \n \
+             discover_legacy: /discover/nobackup/projects/gmao/bcs_shared/legacy_bcs \n \
              discover_couple: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs \n \
              discover_ns: /discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles \n \
 \n \
-Sample GCM tags for discover_ops, discover_lt, discover_couple bc base :\n \
+Sample GCM tags for discover_ops, discover_legacy, discover_couple bc base :\n \
 --------------- \n \
 G40   : Ganymed-4_0  .........  Heracles-5_4_p3 \n \
 ICA   : Icarus  ..............  Jason \n \
@@ -217,7 +217,7 @@ GITOL : 10.3  ................  10.18 \n \
 INL   : Icarus-NL  ...........  Jason-NL \n \
 GITNL : 10.19  ...............  10.23 \n \
 \n \
-Sample DAS tags for discover_ops, discover_lt, discover_couple bc base :\n \
+Sample DAS tags for discover_ops, discover_legacy, discover_couple bc base :\n \
 --------------- \n \
 5B0  : GEOSadas-5_10_0_p2  ..  GEOSadas-5_11_0 \n \
 512  : GEOSadas-5_12_2  .....  GEOSadas-5_16_5\n \
@@ -229,8 +229,8 @@ Sample BC version for discover_ns ( new structure BC base): \n \
 NL3   : Newland version 3 \n \
 NL4   : Newland version 4 \n \
 NL5   : Newland version 5 \n \
-NL6   : Not generated yet \n",
-            "choices": ["discover_ops", "discover_lt", "discover_couple","discover_ns", "other"],
+v06   : Not generated yet \n",
+            "choices": ["discover_ops", "discover_legacy", "discover_couple","discover_ns", "other"],
             "when": lambda x: not x['input:shared:MERRA-2'],
         },
 
@@ -254,7 +254,7 @@ NL6   : Not generated yet \n",
             "type": "select",
             "name": "output:shared:bc_base",
             "message": "Select bcs base for new restarts:",
-            "choices": ["discover_ops", "discover_lt", "discover_couple","discover_ns", "other"],
+            "choices": ["discover_ops", "discover_legacy", "discover_couple","discover_ns", "other"],
         },
 
         {

--- a/pre/remap_restart/remap_upper.py
+++ b/pre/remap_restart/remap_upper.py
@@ -89,7 +89,7 @@ class upperair(remap_base):
 
      in_bcsdir=get_topodir(in_bcsdir)
 
-     topoin = glob.glob(in_bcsdir+'/topo_DYN_ave*.data')
+     topoin = glob.glob(in_bcsdir+'/topo_DYN_ave*.data')[0]
      # link topo file
      cmd = '/bin/ln -s ' + topoin + ' .'
      print('\n'+cmd)

--- a/pre/remap_restart/remap_upper.py
+++ b/pre/remap_restart/remap_upper.py
@@ -8,6 +8,14 @@ import shutil
 import glob
 from remap_base import remap_base
 
+def get_topodir(bcsdir):
+  k = bcsdir.find('/geometry/')
+  if k != -1 :
+     while bcsdir[-1] == '/': bcsdir = bcsdir[0:-1] # remove extra '/'
+     agrid_name = os.path.basename(bcsdir).split('_')[0]
+     bcsdir = bcsdir[0:k]+'/TOPO/TOPO_'+agrid_name + '/smoothed'
+  return bcsdir
+
 class upperair(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
@@ -77,14 +85,19 @@ class upperair(remap_base):
        cmd = '/bin/ln -s  ' + rst + ' ' + f
        print('\n'+cmd)
        subprocess.call(shlex.split(cmd))
+ 
 
+     in_bcsdir=get_topodir(in_bcsdir)
+
+     topoin = glob.glob(in_bcsdir+'/topo_DYN_ave*.data')
      # link topo file
-     topoin = glob.glob(in_bcsdir+'/topo_DYN_ave*')[0]
      cmd = '/bin/ln -s ' + topoin + ' .'
      print('\n'+cmd)
      subprocess.call(shlex.split(cmd))
 
-     topoout = glob.glob(out_bcsdir+'/topo_DYN_ave*')[0]
+
+     out_bcsdir=get_topodir(out_bcsdir)
+     topoout = glob.glob(out_bcsdir+'/topo_DYN_ave*.data')[0]
      cmd = '/bin/ln -s ' + topoout + ' topo_dynave.data'
      print('\n'+cmd)
      subprocess.call(shlex.split(cmd))


### PR DESCRIPTION
This PR is addressing changes implemented in [GEOSgcm_GridComp PR#729](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/729). Changes in that PR affect boundary conditions package output layout. To be able to do restart remapping using python tools we developed we had to add support for that new bcs output structure. 

Updated 12 May 2023 by @gmao-rreichle: Applied "Contingent - DNA" label to indicate that this PR should be merged **after** PR #14.  @sdrabenh, please remove "Contingent - DNA" label when you're ready to merge this PR.  