### PR TITLE
Update CI to use Baselibs 7.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.23.0
+baselibs_version: &baselibs_version v7.13.0
+bcs_version: &bcs_version v11.00.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updates paths to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space.
-- Support for new boundary conditions package output layout
+- Update CI to use Baselibs 7.13.0
 
 ### Fixed
-
-- Speedup remap_restarts.py package by adding more processes to catch tiles for fine resolutions.
 
 ### Removed
 
 ### Deprecated
 
-## [1.2.0] - 2023-04-25
+## [2.0.0] - 2023-05-17
 
 ### Fixed
 
 - Fixed issue with `remap_upper.py` where nc4 files were being linked instead of binary files which FV routines require
+- Speedup remap_restarts.py package by adding more processes to catch tiles for fine resolutions.
 
 ### Changed
 
 - Moved to pass in stretched grid factors to `interp_restarts.x` rather than using a namelist file
+- Updates paths to the legacy bcs data by pointing to the new "bcs_shared" directory in the GMAO project space.
+- Support for new boundary conditions package output layout
+
 
 ## [1.1.1] - 2023-03-29
 


### PR DESCRIPTION
This PR updates the CI to point to Baselibs 7.13.0 which is the version used by GEOSgcm on `main`