### PR TITLE
get catchment tile number from restart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Get catchment tile number from the input restart file instead of input bcs which may be empty
-- Speedup remap_restarts.py package by adding more processes to catch tiles for fine resolutions.
+- Get number of land tiles from input catch restart file if input bcs path is not available (as in GEOSldas).
+- Speed up remap_restarts.py package by adding more processes to catch tiles for fine resolutions.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Get catchment tile number from the input restart file instead of input bcs which may be empty
 - Speedup remap_restarts.py package by adding more processes to catch tiles for fine resolutions.
 
 ### Removed

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -55,9 +55,11 @@ class catchANDcn(remap_base):
      surflay    = config['output']['surface']['surflay']
      in_tilefile = config['input']['surface']['catch_tilefile']
 
+     # determine NPE based on *approximate* number of input and output tiles
+      
      if not in_tilefile :
         if not in_bcsdir:
-           exit("You need to provide either input tile file or the input bcs directory")
+           exit("Must provide either input tile file or input bcs directory")
         in_tilefile  = glob.glob(in_bcsdir+ '/*.til')[0]
 
      out_tilefile = config['output']['surface']['catch_tilefile']
@@ -77,11 +79,11 @@ class catchANDcn(remap_base):
        out_tilenum = int(next(f))
      max_tilenum = max(in_tilenum, out_tilenum)
      NPE = 0
-     if (max_tilenum <= 112573): #M36
+     if   (max_tilenum <=  112573) : # no more than EASEv2_M36
         NPE = 40      
-     elif (max_tilenum <= 1684725) : #M09
+     elif (max_tilenum <= 1684725) : # no more than EASEv2_M09
         NPE = 80
-     elif (max_tilenum <= 2496756) : #C720
+     elif (max_tilenum <= 2496756) : # no more than C720
         NPE = 120
      else:
         NPE = 160

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -55,8 +55,6 @@ class catchANDcn(remap_base):
      surflay    = config['output']['surface']['surflay']
      in_tilefile = config['input']['surface']['catch_tilefile']
 
-     # determine NPE based on *approximate* number of input and output tiles
-      
      if not in_tilefile :
         if not in_bcsdir:
            exit("Must provide either input tile file or input bcs directory")
@@ -66,24 +64,26 @@ class catchANDcn(remap_base):
      if not out_tilefile :
         out_tilefile = glob.glob(out_bcsdir+ '/*.til')[0]
 
-     in_tilenum  = 0
+ # determine NPE based on *approximate* number of input and output tile
+      
+     in_Ntile  = 0
      mime = mimetypes.guess_type(in_rstfile)
      if mime[0] and 'stream' in mime[0]: # binary
-       in_tilenum  = 1684725 # if it is binary, it is safe to assume the maximum is M09
+       in_Ntile  = 1684725 # if it is binary, it is safe to assume the maximum is M09
      else : # nc4 file
        ds = nc.Dataset(in_rstfile)
-       in_tilenum = ds.dimensions['tile'].size
+       in_Ntile = ds.dimensions['tile'].size
        
-     out_tilenum = 0
+     out_Ntile = 0
      with open( out_bcsdir+'/clsm/catchment.def') as f:
-       out_tilenum = int(next(f))
-     max_tilenum = max(in_tilenum, out_tilenum)
+       out_Ntile = int(next(f))
+     max_Ntile = max(in_Ntile, out_Ntile)
      NPE = 0
-     if   (max_tilenum <=  112573) : # no more than EASEv2_M36
+     if   (max_Ntile <=  112573) : # no more than EASEv2_M36
         NPE = 40      
-     elif (max_tilenum <= 1684725) : # no more than EASEv2_M09
+     elif (max_Ntile <= 1684725) : # no more than EASEv2_M09
         NPE = 80
-     elif (max_tilenum <= 2496756) : # no more than C720
+     elif (max_Ntile <= 2496756) : # no more than C720
         NPE = 120
      else:
         NPE = 160

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -7,6 +7,8 @@ import shutil
 import glob
 import ruamel.yaml
 import shlex
+import mimetypes
+import netCDF4 as nc
 from remap_base import remap_base
 
 def get_landdir(bcsdir):
@@ -52,16 +54,25 @@ class catchANDcn(remap_base):
      out_wemin  = config['output']['surface']['wemin']
      surflay    = config['output']['surface']['surflay']
      in_tilefile = config['input']['surface']['catch_tilefile']
+
      if not in_tilefile :
+        if not in_bcsdir:
+           exit("You need to provide either input tile file or the input bcs directory")
         in_tilefile  = glob.glob(in_bcsdir+ '/*.til')[0]
+
      out_tilefile = config['output']['surface']['catch_tilefile']
      if not out_tilefile :
         out_tilefile = glob.glob(out_bcsdir+ '/*.til')[0]
 
-     in_tilenum  = 0 
+     in_tilenum  = 0
+     mime = mimetypes.guess_type(in_rstfile)
+     if mime[0] and 'stream' in mime[0]: # binary
+       in_tilenum  = 1684725 # if it is binary, it is safe to assume the maximum is M09
+     else : # nc4 file
+       ds = nc.Dataset(in_rstfile)
+       in_tilenum = ds.dimensions['tile'].size
+       
      out_tilenum = 0
-     with open( in_bcsdir+'/clsm/catchment.def') as f:
-       in_tilenum = int(next(f))
      with open( out_bcsdir+'/clsm/catchment.def') as f:
        out_tilenum = int(next(f))
      max_tilenum = max(in_tilenum, out_tilenum)


### PR DESCRIPTION
In GEOSldas, the input bcs is not provided when remapping. So it  fails to get the tile number for the input. This PR corrects that issue and get the tile number from input restart file.