### PR TITLE
Add push-to-main to CI for MAPL3 work

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
@@ -1,0 +1,10 @@
+## :memo:  Automatic PR: `main` → `release/MAPL-v3`
+
+### Description
+
+<!-- Write your description here -->
+
+## :file_folder:  Modified files
+<!-- Diff files - START -->
+<!-- Diff files - END -->
+

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -1,0 +1,30 @@
+name: Push to Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - name: Run the action
+        uses: devops-infra/action-pull-request@v0.5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: main
+          target_branch: release/MAPL-v3
+          label: automatic,MAPL3,Skip Changelog
+          template: .github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+          get_diff: true
+          assignee: ${{ github.actor }}
+          old_string: "<!-- Write your description here -->"
+          new_string: ${{ github.event.commits[0].message }}
+          title: Auto PR - main → MAPL-v3 - ${{ github.event.commits[0].message }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add CI step to make PR to MAPL3 on push to `main`
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
The `release/MAPL-v3` tracking branch for MAPL3 was recently added to this repo. As such, we need to keep track of when pushes to `main` occur. This PR adds a CI step that makes a `main` --> `release/MAPL-v3` PR when that happens.v