### PR TITLE
fix edge issue in bin2nc for merra2 restarts to levels other than 72

### DIFF
--- a/pre/remap_restart/bin2nc_merra2_fv.yaml
+++ b/pre/remap_restart/bin2nc_merra2_fv.yaml
@@ -3,12 +3,12 @@ variables:
     long_name: hybrid_sigma_pressure_a
     units: 'Pa'
     dimension:
-       - edges
+       - edge
   - short_name: BK
     long_name: hybrid_sigma_pressure_b
     units: '1'
     dimension:
-       - edges
+       - edge
   - short_name: U
     long_name: eastward_wind
     units: 'm s-1'
@@ -34,7 +34,7 @@ variables:
     long_name: air_pressure
     units: 'Pa'
     dimension:
-       - edges
+       - edge
        - lat
        - lon
   - short_name: PKZ
@@ -62,5 +62,5 @@ dimensions:
   lon: 180
   lat: 1080
   lev: 72
-  edges: 73
+  edge: 73
   time: 1

--- a/pre/remap_restart/remap_bin2nc.py
+++ b/pre/remap_restart/remap_bin2nc.py
@@ -17,7 +17,7 @@ def writeCVars(coordVars,dimensions):
    for v in coordVars:
        if v=='time':
           coordVars[v][:]=0
-       elif (v=='lat') | (v=='lon') | (v=='lev') | (v=='edges'):
+       elif (v=='lat') | (v=='lon') | (v=='lev') | (v=='edge'):
           dsize=dimensions[v]
           coords=np.arange(1,dsize+1)
           coordVars[v][:]=coords
@@ -55,8 +55,8 @@ def writeVar(v, vars, dimensions, bintype, binf):
          for i in range(dimensions.get('lev')):
             rec = binf.read_reals(dtype=bintype)
             var[i,:,:]=rec
-      elif 'edges' in dims:
-         for i in range(dimensions.get('edges')):
+      elif 'edge' in dims:
+         for i in range(dimensions.get('edge')):
             rec = binf.read_reals(dtype=bintype)
             var[i,:,:]=rec
       else:
@@ -64,7 +64,7 @@ def writeVar(v, vars, dimensions, bintype, binf):
          var[:,:]=rec
    # is just lev
    else:
-      if 'edges' in dims:
+      if 'edge' in dims:
          rec = binf.read_reals(dtype=bintype)
          var[:]=rec
 
@@ -90,10 +90,10 @@ def defineDimVars(fid,dims):
           setattr(newVar,'positive','down')
           setattr(newVar,'formulaTerms','ap: ak b: bk ps: ps p0: p00')
           coordVars.update([(d,newVar)])
-       if d=="edges":
+       if d=="edge":
           newVar=fid.createVariable(d,'f8',d)
           setattr(newVar,'units','level')
-          setattr(newVar,'long_name','sigma_at_layer edges')
+          setattr(newVar,'long_name','sigma_at_layer edge')
           setattr(newVar,'standard_name','atmosphere_hybrid_sigma_pressure_coordinate')
           setattr(newVar,'coordinate','eta')
           setattr(newVar,'positive','down')


### PR DESCRIPTION
These changes are required for properly regrinding MERRA-2 L72 data to any other vertical grid.