### PR TITLE
Remove mask from read_Reynolds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+mask from read_reynolds.F90
+
 ### Deprecated
 
 ## [2.0.7] - 2024-02-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- mask from read_reynolds.F90
+- mask from `read_reynolds.F90`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-mask from read_reynolds.F90
+- mask from read_reynolds.F90
 
 ### Deprecated
 

--- a/pre/NSIDC-OSTIA_SST-ICE_blend/read_Reynolds.F90
+++ b/pre/NSIDC-OSTIA_SST-ICE_blend/read_Reynolds.F90
@@ -1,19 +1,17 @@
 !
-      SUBROUTINE read_Reynolds(ncFileName, maskFileName, NLAT, NLON, LAT, LON, &
-                               SST, ICE, MASK, myUNDEF)
+      SUBROUTINE read_Reynolds(ncFileName, NLAT, NLON, LAT, LON, &
+                               SST, ICE, myUNDEF)
 !---------------------------------------------------------------------------
           USE netcdf
           IMPLICIT NONE
 
           CHARACTER (LEN = *),             INTENT(IN)    :: ncFileName
-          CHARACTER (LEN = *),             INTENT(IN)    :: maskFileName
           INTEGER,                         INTENT(IN)    :: NLAT, NLON
           REAL,                            INTENT(IN)    :: myUNDEF
           REAL, DIMENSION(NLAT),           INTENT(OUT)   :: LAT
           REAL, DIMENSION(NLON),           INTENT(OUT)   :: LON
           REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: SST
           REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: ICE
-          REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: MASK
 
 ! GET TO KNOW THESE BY ncdump -h
           REAL, PARAMETER :: sst_FillValue       = -999
@@ -22,10 +20,9 @@
           REAL, PARAMETER :: ice_FillValue       = -999
           REAL, PARAMETER :: ice_offset          =  0.0
           REAL, PARAMETER :: ice_scale_factor    =  0.01
-
           
 ! netCDF ID for the file and data variable.
-          INTEGER :: ncid, varid1, varid2, varid3, varid4, varid_mask
+          INTEGER :: ncid, varid1, varid2, varid3, varid4
 !         INTEGER :: iLON
 !         REAL    :: dLon
 !---------------------------------------------------------------------------
@@ -66,14 +63,6 @@
               ICE = myUNDEF
           ENDWHERE
 
-! .....................................................................
-! Read a land sea mask
-
-          print*, 'Reading mask from: ', maskFileName
-          CALL check( nf90_open(maskFileName, nf90_nowrite, ncid))
-          CALL check( nf90_inq_varid(ncid, "lsmaski", varid_mask))
-          CALL check( nf90_get_var(ncid, varid_mask, MASK))
-          CALL check( nf90_close(ncid))
 ! .....................................................................
 
 ! Reynolds has lon: (0, 360). 


### PR DESCRIPTION
This PR eliminates reference to read of a user defined _land_sea_mask within `read_Reynolds.F90`.

That mask and read was in [put in](https://github.com/GEOS-ESM/GEOS_Util/commit/8fb22060116c7cc5fdfada56a9a39988a3fc5ed6)
and the mask file or path to it was not committed or even read interface was not provided. Hence this PR proposes to remove it.

**Answers are preserved.**



