### PR TITLE
Fix time_ave.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix quote-v-comma issue in `time_ave.rc` that ESMF 8.6.1 was triggered
-
 ### Removed
 
 ### Deprecated
+
+## [2.1.1] - 2024-07-26
+
+### Fixed
+
+- Fix quote-v-comma issue in `time_ave.rc` that ESMF 8.6.1 was triggered by.
 
 ## [2.1.0] - 2024-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix quote-v-comma issue in `time_ave.rc` that ESMF 8.6.1 was triggered
+
 ### Removed
 
 ### Deprecated

--- a/post/time_ave.rc
+++ b/post/time_ave.rc
@@ -31,90 +31,90 @@ QUADRATICS: 'u'     , 'v'     ,
             'wstar' , 'qstar' , 'WSQS' ,
             ::
 
-ALIASES:    'u'  ,  'U'       '
-            'u'  ,  'uwnd'    '
-            'u'  ,  'UWND'    '
-            'u'  ,  'ugrd'    '
-            'u'  ,  'UGRD'    '
-            'u'  ,  'ugrdprs' '
-            'u'  ,  'UGRDPRS' '
+ALIASES:    'u'  ,  'U'       ,
+            'u'  ,  'uwnd'    ,
+            'u'  ,  'UWND'    ,
+            'u'  ,  'ugrd'    ,
+            'u'  ,  'UGRD'    ,
+            'u'  ,  'ugrdprs' ,
+            'u'  ,  'UGRDPRS' ,
 
-            'v'  ,  'V'       '
-            'v'  ,  'vwnd'    '
-            'v'  ,  'VWND'    '
-            'v'  ,  'vgrd'    '
-            'v'  ,  'VGRD'    '
-            'v'  ,  'vgrdprs' '
-            'v'  ,  'VGRDPRS' '
+            'v'  ,  'V'       ,
+            'v'  ,  'vwnd'    ,
+            'v'  ,  'VWND'    ,
+            'v'  ,  'vgrd'    ,
+            'v'  ,  'VGRD'    ,
+            'v'  ,  'vgrdprs' ,
+            'v'  ,  'VGRDPRS' ,
 
-            't'  ,  'T'       '
-            't'  ,  'tmp'     '
-            't'  ,  'TMP'     '
-            't'  ,  'tmpu'    '
-            't'  ,  'TMPU'    '
-            't'  ,  'tmpprs'  '
-            't'  ,  'TMPPRS'  '
+            't'  ,  'T'       ,
+            't'  ,  'tmp'     ,
+            't'  ,  'TMP'     ,
+            't'  ,  'tmpu'    ,
+            't'  ,  'TMPU'    ,
+            't'  ,  'tmpprs'  ,
+            't'  ,  'TMPPRS'  ,
 
-            'qv' ,  'q'       '
-            'qv' ,  'Q'       '
-            'qv' ,  'QV'      '
-            'qv' ,  'sphu'    '
-            'qv' ,  'SPHU'    '
+            'qv' ,  'q'       ,
+            'qv' ,  'Q'       ,
+            'qv' ,  'QV'      ,
+            'qv' ,  'sphu'    ,
+            'qv' ,  'SPHU'    ,
 
-            'ql' ,  'QL'      '
+            'ql' ,  'QL'      ,
 
-            'qi' ,  'QI'      '
+            'qi' ,  'QI'      ,
 
-            'h'  ,  'H'       '
-            'h'  ,  'hgt'     '
-            'h'  ,  'HGT'     '
-            'h'  ,  'hght'    '
-            'h'  ,  'HGHT'    '
-            'h'  ,  'hgtprs'  '
-            'h'  ,  'HGTPRS'  '
-            'h'  ,  'z'       '
-            'h'  ,  'Z'       '
+            'h'  ,  'H'       ,
+            'h'  ,  'hgt'     ,
+            'h'  ,  'HGT'     ,
+            'h'  ,  'hght'    ,
+            'h'  ,  'HGHT'    ,
+            'h'  ,  'hgtprs'  ,
+            'h'  ,  'HGTPRS'  ,
+            'h'  ,  'z'       ,
+            'h'  ,  'Z'       ,
 
-            'ustar'  ,  'U'       '
-            'ustar'  ,  'uwnd'    '
-            'ustar'  ,  'UWND'    '
-            'ustar'  ,  'ugrd'    '
-            'ustar'  ,  'UGRD'    '
-            'ustar'  ,  'ugrdprs' '
-            'ustar'  ,  'UGRDPRS' '
+            'ustar'  ,  'U'       ,
+            'ustar'  ,  'uwnd'    ,
+            'ustar'  ,  'UWND'    ,
+            'ustar'  ,  'ugrd'    ,
+            'ustar'  ,  'UGRD'    ,
+            'ustar'  ,  'ugrdprs' ,
+            'ustar'  ,  'UGRDPRS' ,
 
-            'vstar'  ,  'V'       '
-            'vstar'  ,  'vwnd'    '
-            'vstar'  ,  'VWND'    '
-            'vstar'  ,  'vgrd'    '
-            'vstar'  ,  'VGRD'    '
-            'vstar'  ,  'vgrdprs' '
-            'vstar'  ,  'VGRDPRS' '
+            'vstar'  ,  'V'       ,
+            'vstar'  ,  'vwnd'    ,
+            'vstar'  ,  'VWND'    ,
+            'vstar'  ,  'vgrd'    ,
+            'vstar'  ,  'VGRD'    ,
+            'vstar'  ,  'vgrdprs' ,
+            'vstar'  ,  'VGRDPRS' ,
 
-            'tstar'  ,  'T'       '
-            'tstar'  ,  'tmp'     '
-            'tstar'  ,  'TMP'     '
-            'tstar'  ,  'tmpu'    '
-            'tstar'  ,  'TMPU'    '
-            'tstar'  ,  'tmpprs'  '
-            'tstar'  ,  'TMPPRS'  '
+            'tstar'  ,  'T'       ,
+            'tstar'  ,  'tmp'     ,
+            'tstar'  ,  'TMP'     ,
+            'tstar'  ,  'tmpu'    ,
+            'tstar'  ,  'TMPU'    ,
+            'tstar'  ,  'tmpprs'  ,
+            'tstar'  ,  'TMPPRS'  ,
 
-            'qstar'  ,  'q'       '
-            'qstar'  ,  'Q'       '
-            'qstar'  ,  'qv'      '
-            'qstar'  ,  'QV'      '
-            'qstar'  ,  'sphu'    '
-            'qstar'  ,  'SPHU'    '
+            'qstar'  ,  'q'       ,
+            'qstar'  ,  'Q'       ,
+            'qstar'  ,  'qv'      ,
+            'qstar'  ,  'QV'      ,
+            'qstar'  ,  'sphu'    ,
+            'qstar'  ,  'SPHU'    ,
 
-            'wstar'  ,  'omega'   '
-            'wstar'  ,  'OMEGA'   '
-            'omega'  ,  'OMEGA'   '
+            'wstar'  ,  'omega'   ,
+            'wstar'  ,  'OMEGA'   ,
+            'omega'  ,  'OMEGA'   ,
 
-            'epv'    ,  'EPV'     '
+            'epv'    ,  'EPV'     ,
 
-            'o3'     ,  'O3'      '
-            'o3'     ,  'OZ'      '
-            'o3'     ,  'ozone'   '
-            'o3'     ,  'OZONE'   '
+            'o3'     ,  'O3'      ,
+            'o3'     ,  'OZ'      ,
+            'o3'     ,  'ozone'   ,
+            'o3'     ,  'OZONE'   ,
 
             ::


### PR DESCRIPTION
As found by @lltakacs, @sdrabenh and others, `time_ave.x` is "halting" when run in v11.6.0.

Thanks to work by @bena-nasa it was discovered that the update to ESMF 8.6.1 caused this. The reason seems to be ESMF 8.6.0 and older were allowing a badly written RC file which had ending quotes rather than commas. But in 8.6.1, this is doesn't fly anymore.

So we convert the quotes to commas.