### PR TITLE
Add GEOS-IT option for remap restarts

### DIFF
--- a/pre/remap_restart/remap_analysis.py
+++ b/pre/remap_restart/remap_analysis.py
@@ -23,7 +23,10 @@ import fnmatch
 class analysis(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
-     self.copy_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.copy_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.copy_geosit()
 
   def remap(self):
      config = self.config
@@ -125,7 +128,10 @@ class analysis(remap_base):
      print( "cd " + cwdir)
      os.chdir(cwdir)
 
-     self.remove_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.remove_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.remove_geosit()
 
   def get_grid_kind(this, grid):
      hgrd = {}
@@ -155,6 +161,47 @@ class analysis(remap_base):
      traks= glob.glob(rst_dir + '/*.trak.GDA.rst*')
      analysis_in = bkgs + sfcs + traks + anasat
      return list(dict.fromkeys(analysis_in))
+
+  def copy_geosit(self):
+    if not self.config['input']['shared']['GEOS-IT']:
+        return
+     
+    expid = self.config['input']['shared']['expid']
+    yyyymmddhh_ = str(self.config['input']['shared']['yyyymmddhh'])
+    yyyy_ = yyyymmddhh_[0:4]
+    mm_   = yyyymmddhh_[4:6]
+    day_  = yyyymmddhh_[6:8]  # Extract the day from yyyymmddhh_
+     
+    time_suffix = '_21z.tar'
+     
+    geos_it_rst_dir = '/discover/nobackup/projects/gmao/geos-it/dao_ops/archive/' + expid + '/rs/Y' + yyyy_ + '/M' + mm_ + '/'
+    rst_dir = self.config['input']['shared']['rst_dir'] + '/'
+    os.makedirs(rst_dir, exist_ok=True)
+
+    print('Stage GEOS-IT restarts \n from \n    ' + geos_it_rst_dir + '\n to\n    ' + rst_dir + '\n')
+     
+    # Only use the specific day from yyyymmddhh_
+    filename = f'{expid}.rst.{yyyy_}{mm_}{day_}{time_suffix}'
+    src_file = os.path.join(geos_it_rst_dir, filename)
+    dest_file = os.path.join(rst_dir, filename)
+
+    if os.path.exists(src_file):
+        print(f"Copying file {src_file} to {dest_file}")
+        shutil.copy(src_file, dest_file)
+     
+        # Untar the .tar file using the tar command
+        if os.path.exists(dest_file):
+            print(f"Untarring {dest_file} to {rst_dir}")
+            try:
+                subprocess.run(['tar', '-xf', dest_file, '-C', rst_dir], check=True)
+                print(f"Untarred {dest_file} successfully.")
+            except subprocess.CalledProcessError as e:
+                print(f"Error untarring {dest_file}: {e}")
+
+        # Optionally remove the tar file after extraction
+        os.remove(dest_file)
+    else:
+        print(f"File {src_file} does not exist.")
 
   def copy_merra2(self):
     if not self.config['input']['shared']['MERRA-2']:

--- a/pre/remap_restart/remap_base.py
+++ b/pre/remap_restart/remap_base.py
@@ -33,6 +33,10 @@ class remap_base(object):
     if self.config['input']['shared']['MERRA-2']:
       print(" remove temporary folder that contains MERRA-2 archived files ... \n")
       subprocess.call(['/bin/rm', '-rf', self.config['input']['shared']['rst_dir']])
+  def remove_geosit(self):
+    if self.config['input']['shared']['GEOS-IT']:
+      print(" remove temporary folder that contains GEOS-IT archived files ... \n")
+      subprocess.call(['/bin/rm', '-rf', self.config['input']['shared']['rst_dir']])
 
   def copy_without_remap(self, restarts_in, compared_file_in, compared_file_out, suffix, catch=False):
 #

--- a/pre/remap_restart/remap_catchANDcn.py
+++ b/pre/remap_restart/remap_catchANDcn.py
@@ -23,7 +23,10 @@ from remap_utils import *
 class catchANDcn(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
-     self.copy_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.copy_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.copy_geosit()
 
   def remap(self):
      if not self.config['output']['surface']['remap_catch']:
@@ -222,7 +225,10 @@ $esma_mpirun_X $mk_catchANDcnRestarts_X $params
      print( "cd " + cwdir)
      os.chdir(cwdir)
 
-     self.remove_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.remove_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.remove_geosit()
 
   def copy_merra2(self):
     if not self.config['input']['shared']['MERRA-2']:
@@ -247,6 +253,48 @@ $esma_mpirun_X $mk_catchANDcnRestarts_X $params
     dest = rst_dir + '/'+fname
     print("Copy file "+f +" to " + rst_dir)
     shutil.copy(f, dest)
+
+  def copy_geosit(self):
+    if not self.config['input']['shared']['GEOS-IT']:
+        return
+
+    expid = self.config['input']['shared']['expid']
+    yyyymmddhh_ = str(self.config['input']['shared']['yyyymmddhh'])
+    yyyy_ = yyyymmddhh_[0:4]
+    mm_   = yyyymmddhh_[4:6]
+    day_  = yyyymmddhh_[6:8]  # Extract the day from yyyymmddhh_
+
+    time_suffix = '_21z.tar'
+
+    geos_it_rst_dir = '/discover/nobackup/projects/gmao/geos-it/dao_ops/archive/' + expid + '/rs/Y' + yyyy_ + '/M' + mm_ + '/'
+    rst_dir = self.config['input']['shared']['rst_dir'] + '/'
+    os.makedirs(rst_dir, exist_ok=True)
+
+    print('Stage GEOS-IT restarts \n from \n    ' + geos_it_rst_dir + '\n to\n    ' + rst_dir + '\n')
+
+    # Only use the specific day from yyyymmddhh_
+    filename = f'{expid}.rst.{yyyy_}{mm_}{day_}{time_suffix}'
+    src_file = os.path.join(geos_it_rst_dir, filename)
+    dest_file = os.path.join(rst_dir, filename)
+
+    if os.path.exists(src_file):
+        print(f"Copying file {src_file} to {dest_file}")
+        shutil.copy(src_file, dest_file)
+
+        # Untar the .tar file using the tar command
+        if os.path.exists(dest_file):
+            print(f"Untarring {dest_file} to {rst_dir}")
+            try:
+                subprocess.run(['tar', '-xf', dest_file, '-C', rst_dir], check=True)
+                print(f"Untarred {dest_file} successfully.")
+            except subprocess.CalledProcessError as e:
+                print(f"Error untarring {dest_file}: {e}")
+
+        # Optionally remove the tar file after extraction
+        os.remove(dest_file)
+    else:
+        print(f"File {src_file} does not exist.")
+
 
 def ask_catch_questions():
    catch_input_shared_rst_dir = ''
@@ -342,7 +390,7 @@ def ask_catch_questions():
         {
             "type": "select",
             "name": "output:shared:ogrid",
-            "message": message_ogrid_in,
+            "message": message_ogrid_new,
             "choices": choices_ogrid_data,
             "default": lambda x: data_ocean_default(x.get('output:shared:agrid')),
             "when": lambda x : x['output:surface:EASE_grid'] == 'Cubed-Sphere',

--- a/pre/remap_restart/remap_command_line.py
+++ b/pre/remap_restart/remap_command_line.py
@@ -39,6 +39,7 @@ def parse_args(program_description):
      help = "Use command line as input",
     )
     p_command.add_argument('-merra2', action='store_true', default= False, help='use merra2 restarts')
+    p_command.add_argument('-geosit', action='store_true', default= False, help='use GEOSIT restarts')
 
     p_command.add_argument('-ymdh',              help='yyyymmddhh year month date hour of input and new restarts')
     p_command.add_argument('-grout',             help='Grid ID/resolution of new restarts, format C[xxx] (cubed-sphere only for now)')
@@ -91,11 +92,14 @@ def get_answers_from_command_line(cml):
 
    answers = {}
    answers["input:shared:MERRA-2"]     = cml.merra2
+   answers["input:shared:GEOS-IT"]     = cml.geosit
    answers["input:shared:yyyymmddhh"]  = cml.ymdh
    answers["input:shared:omodel"]      = cml.ocnmdlin
    answers["output:shared:out_dir"]    = os.path.abspath(cml.out_dir + '/')
    if  cml.merra2:
       init_merra2(answers)
+   if  cml.geosit:
+      init_geosit(answers)
    else:   
       answers["input:shared:bc_version"]   = cml.bcvin
       answers["input:surface:catch_model"] = cml.catch_model

--- a/pre/remap_restart/remap_lake_landice_saltwater.py
+++ b/pre/remap_restart/remap_lake_landice_saltwater.py
@@ -12,6 +12,7 @@
 import os
 import subprocess as sp
 import shutil
+import subprocess
 import glob
 import ruamel.yaml
 import shlex
@@ -23,7 +24,10 @@ from remap_bin2nc import bin2nc
 class lake_landice_saltwater(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
-     self.copy_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.copy_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.copy_geosit()
 
   def remap(self):
      if not self.config['output']['surface']['remap_water']:
@@ -170,7 +174,10 @@ class lake_landice_saltwater(remap_base):
      print('cd ' + cwdir)
      os.chdir(cwdir)
 
-     self.remove_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.remove_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.remove_geosit()
 
   def run_and_log(self, cmd, log_name):
      print('\n'+cmd)
@@ -244,6 +251,48 @@ class lake_landice_saltwater(remap_base):
        bin2nc(dest, ncdest, yaml_file)
        os.remove(dest)
 
+  def copy_geosit(self):
+    if not self.config['input']['shared']['GEOS-IT']:
+        return
+
+    expid = self.config['input']['shared']['expid']
+    yyyymmddhh_ = str(self.config['input']['shared']['yyyymmddhh'])
+    yyyy_ = yyyymmddhh_[0:4]
+    mm_   = yyyymmddhh_[4:6]
+    day_  = yyyymmddhh_[6:8]  # Extract the day from yyyymmddhh_
+
+    time_suffix = '_21z.tar'
+
+    geos_it_rst_dir = '/discover/nobackup/projects/gmao/geos-it/dao_ops/archive/' + expid + '/rs/Y' + yyyy_ + '/M' + mm_ + '/'
+    rst_dir = self.config['input']['shared']['rst_dir'] + '/'
+    os.makedirs(rst_dir, exist_ok=True)
+
+    print('Stage GEOS-IT restarts \n from \n    ' + geos_it_rst_dir + '\n to\n    ' + rst_dir + '\n')
+
+    # Only use the specific day from yyyymmddhh_
+    filename = f'{expid}.rst.{yyyy_}{mm_}{day_}{time_suffix}'
+    src_file = os.path.join(geos_it_rst_dir, filename)
+    dest_file = os.path.join(rst_dir, filename)
+
+    if os.path.exists(src_file):
+        print(f"Copying file {src_file} to {dest_file}")
+        shutil.copy(src_file, dest_file)
+
+        # Untar the .tar file using the tar command
+        if os.path.exists(dest_file):
+            print(f"Untarring {dest_file} to {rst_dir}")
+            try:
+                subprocess.run(['tar', '-xf', dest_file, '-C', rst_dir], check=True)
+                print(f"Untarred {dest_file} successfully.")
+            except subprocess.CalledProcessError as e:
+                print(f"Error untarring {dest_file}: {e}")
+
+        # Optionally remove the tar file after extraction
+        os.remove(dest_file)
+    else:
+        print(f"File {src_file} does not exist.")
+
+#
 if __name__ == '__main__' :
    lls = lake_landice_saltwater(params_file='remap_params.yaml')
    lls.remap()

--- a/pre/remap_restart/remap_params.tpl
+++ b/pre/remap_restart/remap_params.tpl
@@ -10,6 +10,7 @@ input:
     hydrostatic: 0
   shared:
     MERRA-2: false
+    GEOS-IT: false
     stretch: false
     # (coupled) ocean model: data, MOM5, MOM6
     omodel: data

--- a/pre/remap_restart/remap_questions.py
+++ b/pre/remap_restart/remap_questions.py
@@ -50,11 +50,29 @@ def validate_merra2_time(text):
          return False 
    else:
      return False
+
+def validate_geosit_time(text):
+   if len(text) == 10 :
+      dd = text[6:8]
+      hh = text[8:]
+      if dd in ['14','28'] and hh in ['21']:
+         return True
+      else:
+         return False
+   else:
+     return False
+
 def SITE_MERRA2(x):
   if GEOS_SITE == "NAS":
      x['input:shared:MERRA-2']= False
      return False
   return True
+
+def SITE_GEOSIT(x):
+  if GEOS_SITE == "NAS":
+     x['input:shared:GEOS-IT']= False
+     return False
+  return True 
 
 def ask_questions():
 
@@ -70,30 +88,46 @@ def ask_questions():
             "when": lambda x: SITE_MERRA2(x),
         },
         {
+            "type": "confirm",
+            "name": "input:shared:GEOS-IT",
+            "message": "Remap archived GEOS-IT restarts? (NCCS/Discover only; elsewhere, select 'N' and complete full config; requires nc4 restarts.)\n",
+            "default": False,
+            "when": lambda x: SITE_GEOSIT(x) and not x.get("input:shared:MERRA-2", False),
+        },
+        {
             "type": "path",
             "name": "input:shared:rst_dir",
             "message": "Enter input directory with restart files to be remapped:\n",
-            "when": lambda x: not x['input:shared:MERRA-2'],
+            "when": lambda x: not x.get("input:shared:MERRA-2", False) and not x.get("input:shared:GEOS-IT", False),
         },
         {
             "type": "text",
             "name": "input:shared:yyyymmddhh",
-            "message": (message_datetime + ".)\n"),
-            "validate": lambda text: len(text)==10 ,
-            "when": lambda x: not x['input:shared:MERRA-2'] and not fvcore_info(x),
+            "message": "Enter the restart date and hour (YYYYMMDDHH):\n",
+            "validate": lambda text: len(text) == 10,
+            "when": lambda x: not x.get('input:shared:MERRA-2', False) and not x.get('input:shared:GEOS-IT', False) and not fvcore_info(x),
         },
         {
             "type": "text",
             "name": "input:shared:yyyymmddhh",
-            "message": (message_datetime + "; hour = 03, 09, 15, or 21 [z].)\n"),
-            "validate": lambda text: validate_merra2_time(text) ,
-            "when": lambda x: x['input:shared:MERRA-2'],
+            "message": "Enter the restart date and hour (YYYYMMDDHH, hour = 03, 09, 15, or 21 [z]):\n",
+            "validate": lambda text: validate_merra2_time(text),
+            "when": lambda x: x.get("input:shared:MERRA-2", False),
         },
+        {
+            "type": "text",
+            "name": "input:shared:yyyymmddhh",
+            "message": "Enter the restart date and hour (YYYYMMDDHH, Only days available are 14th and 28th and only hour = 21 [z]):\n",
+            "validate": lambda text: validate_geosit_time(text),
+            "when": lambda x: x.get("input:shared:GEOS-IT", False) and not x.get("input:shared:MERRA-2", False),
+        },
+
         {
             "type": "path",
             "name": "output:shared:out_dir",
             "message": message_out_dir,
         },
+
 
         # dummy (invisible) question to run function that initializes MERRA-2 config
         {
@@ -103,33 +137,41 @@ def ask_questions():
             # always return false, so question never shows but changes x
             "when": lambda x: init_merra2(x),
         },
-
+        # dummy (invisible) question to run function that initializes GEOS-IT config
         {
-            "type": "text",
-            "name": "input:shared:agrid",
-            "message": message_agrid_in,
-            "validate": lambda text : text in validate_agrid,
-            # if it is merra-2 or has_fvcore, agrid is deduced
-            "when": lambda x: not x['input:shared:MERRA-2'] and not fvcore_info(x),
+            "type": "path",
+            "name": "output:shared:out_dir",
+            "message": "init GEOSIT\n",
+            # always return false, so question never shows but changes x
+            "when": lambda x: init_geosit(x),
         },
 
+        # for both MERRA2 and GEOS-IT
         {
-            "type": "select",
-            "name": "input:shared:omodel",
-            "message": "Select ocean model of input restarts:\n",
-            "choices": choices_omodel,
-            "default": "data",
-            "when": lambda x: not x['input:shared:MERRA-2']
+           "type": "text",
+           "name": "input:shared:agrid",
+           "message": message_agrid_in,
+           "validate": lambda text: text in validate_agrid,
+           "when": lambda x: not x['input:shared:MERRA-2'] and not x['input:shared:GEOS-IT'] and not fvcore_info(x),
         },
 
-        {
-            "type": "select",
-            "name": "input:shared:ogrid",
-            "message": message_ogrid_in,
-            "choices": choices_ogrid_data,
-            "default": lambda x: data_ocean_default(x.get('input:shared:agrid')),
-            "when": lambda x: x.get('input:shared:omodel') == 'data' and not x['input:shared:MERRA-2'],
-        },
+        {        
+           "type": "select",
+           "name": "input:shared:omodel",
+           "message": "Select ocean model of input restarts:\n",
+           "choices": choices_omodel,
+           "default": "data",
+           "when": lambda x: not x['input:shared:MERRA-2'] and not x['input:shared:GEOS-IT'],
+       },
+
+       {   
+          "type": "select",
+          "name": "input:shared:ogrid",
+          "message": message_ogrid_in,
+          "choices": choices_ogrid_data,
+          "default": lambda x: data_ocean_default(x.get('input:shared:agrid')),
+          "when": lambda x: x.get('input:shared:omodel') == 'data' and not x['input:shared:MERRA-2'] and not x['input:shared:GEOS-IT'],
+       },
 
         # dummy (invisible) question to remove parenthetical comments from selected input:shared:ogrid
         {
@@ -232,7 +274,7 @@ def ask_questions():
             "name": "input:shared:bc_version",
             "message": message_bc_ops_in,
             "choices": choices_bc_ops,
-            "when": lambda x: not x["input:shared:MERRA-2"],
+            "when": lambda x: not x["input:shared:MERRA-2"] and not x["input:shared:GEOS-IT"],
         },
 
         {
@@ -249,7 +291,7 @@ def ask_questions():
             "message": message_bc_ops_new,
             "choices": choices_bc_ops,
             "default": "NL3",
-            "when": lambda x: x["input:shared:MERRA-2"],
+            "when": lambda x: x["input:shared:MERRA-2"] or x["input:shared:GEOS-IT"],
         },
 
         {
@@ -258,7 +300,7 @@ def ask_questions():
             "message": "Select BCs version for new restarts:\n",
             "choices": choices_bc_ops,
             "default": "NL3",
-            "when": lambda x: not x["input:shared:MERRA-2"],
+            "when": lambda x: not x["input:shared:MERRA-2"] and not x["input:shared:GEOS-IT"],
         },
 
         {
@@ -355,7 +397,6 @@ def ask_questions():
             "message": "Remap bkg files?  (Required by ADAS but not mapped onto ADAS grid; run one ADAS cycle to spin up.) ",
             "default": False,
         },
-
         {
             "type": "confirm",
             "name": "output:analysis:lcv",
@@ -419,11 +460,12 @@ def ask_questions():
    answers['output:shared:out_dir'] = os.path.abspath(answers['output:shared:out_dir'])
 
    if answers.get('input:air:nlevel') : del answers['input:air:nlevel']
-   if answers["output:surface:remap"] and not answers["input:shared:MERRA-2"]:  
+   if answers["output:surface:remap"] and not answers["input:shared:MERRA-2"] and not answers["input:shared:GEOS-IT"]:  
       answers["input:surface:catch_model"] = catch_model(answers)
    answers["output:surface:remap_water"] = answers["output:surface:remap"]
    answers["output:surface:remap_catch"] = answers["output:surface:remap"]
    del answers["output:surface:remap"]
+
  
    return answers
 

--- a/pre/remap_restart/remap_upper.py
+++ b/pre/remap_restart/remap_upper.py
@@ -22,7 +22,10 @@ import netCDF4 as nc
 class upperair(remap_base):
   def __init__(self, **configs):
      super().__init__(**configs)
-     self.copy_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.copy_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.copy_geosit()
 
   def remap(self):
      if not self.config['output']['air']['remap'] :
@@ -332,7 +335,10 @@ endif
      print('cd ' + cwdir)
      os.chdir(cwdir)
 
-     self.remove_merra2()
+     if self.config['input']['shared']['MERRA-2']:
+        self.remove_merra2()
+     if self.config['input']['shared']['GEOS-IT']:
+        self.remove_geosit()
 
   def find_rst(self):
      rst_dir = self.config['input']['shared']['rst_dir']
@@ -390,6 +396,48 @@ endif
        else:
          bin2nc(dest, ncdest, yaml_file)
        os.remove(dest)
+
+  def copy_geosit(self):
+    if not self.config['input']['shared']['GEOS-IT']:
+        return
+
+    expid = self.config['input']['shared']['expid']
+    yyyymmddhh_ = str(self.config['input']['shared']['yyyymmddhh'])
+    yyyy_ = yyyymmddhh_[0:4]
+    mm_   = yyyymmddhh_[4:6]
+    day_  = yyyymmddhh_[6:8]  # Extract the day from yyyymmddhh_
+
+    time_suffix = '_21z.tar'
+
+    geos_it_rst_dir = '/discover/nobackup/projects/gmao/geos-it/dao_ops/archive/' + expid + '/rs/Y' + yyyy_ + '/M' + mm_ + '/'
+    rst_dir = self.config['input']['shared']['rst_dir'] + '/'
+    os.makedirs(rst_dir, exist_ok=True)
+
+    print('Stage GEOS-IT restarts \n from \n    ' + geos_it_rst_dir + '\n to\n    ' + rst_dir + '\n')
+
+    # Only use the specific day from yyyymmddhh_
+    filename = f'{expid}.rst.{yyyy_}{mm_}{day_}{time_suffix}'
+    src_file = os.path.join(geos_it_rst_dir, filename)
+    dest_file = os.path.join(rst_dir, filename)
+
+    if os.path.exists(src_file):
+        print(f"Copying file {src_file} to {dest_file}")
+        shutil.copy(src_file, dest_file)
+
+        # Untar the .tar file using the tar command
+        if os.path.exists(dest_file):
+            print(f"Untarring {dest_file} to {rst_dir}")
+            try:
+                subprocess.run(['tar', '-xf', dest_file, '-C', rst_dir], check=True)
+                print(f"Untarred {dest_file} successfully.")
+            except subprocess.CalledProcessError as e:
+                print(f"Error untarring {dest_file}: {e}")
+
+        # Optionally remove the tar file after extraction
+        os.remove(dest_file)
+    else:
+        print(f"File {src_file} does not exist.")
+
 
 if __name__ == '__main__' :
    air = upperair(params_file='remap_params.yaml')


### PR DESCRIPTION
I added remapping from GEOS-IT restarts. 
GEOS-IT has only two dates available for users to be remapped, day 14th and day 28th, and they are in .tar format.

This PR will address these two issues:
https://github.com/GEOS-ESM/GEOS_Util/issues/62 
https://github.com/GEOS-ESM/GEOS_Util/issues/72

PR was tested for a run using the on-screen option for GEOS-IT vs. copying and un-tar files manually and using the tool to remap my restarts. The difference is zero diff. 