### PR TITLE
v12: Fix for SLES15 remapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.23.0
-#bcs_version: &bcs_version v11.5.0
+#baselibs_version: &baselibs_version v8.5.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -21,7 +21,10 @@ workflows:
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)
@@ -45,7 +48,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue with SLES15 in remapping
+
 ### Removed
 
 ### Deprecated

--- a/pre/remap_restart/remap_command_line.py
+++ b/pre/remap_restart/remap_command_line.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # remap_restarts package:
-#   remap_command_line.py parses and converts the command-line arguments and converts the information 
+#   remap_command_line.py parses and converts the command-line arguments and converts the information
 #   into matching "Answers" for the questionary (remap_questions.py)
 #
 import os
@@ -63,7 +63,7 @@ def parse_args(program_description):
     p_command.add_argument('-ocnmdlout',   default='data',    help='Ocean model for new restarts',          choices=choices_omodel)
     p_command.add_argument('-in_stretch',  default=False,     help='Stretched CS params of input restarts', choices=choices_stretch)
     p_command.add_argument('-out_stretch', default=False,     help='Stretched CS params for new restarts',  choices=choices_stretch)
-    
+
     # Unlike remap_questions.py, command-line feature does not deduce Catch vs. CatchCN[40,45] for simplicity, thus requires input argument
     p_command.add_argument('-catch_model',default='catch',    help='Catchment[CN] model', choices=choices_catchmodel)
 
@@ -80,10 +80,7 @@ def parse_args(program_description):
     p_command.add_argument('-qos',        default="",    help="slurm_pbs quality-of-service", choices=['', 'debug', 'allnccs', 'normal'])
     account = get_account()
     p_command.add_argument('-account',    default=account,    help="slurm_pbs account")
-    if (BUILT_ON_SLES15):
-      p_command.add_argument('-partition',  default='scutest',help="slurm_pbs partition")
-    else:
-      p_command.add_argument('-partition',  default='',       help="slurm_pbs partition")
+    p_command.add_argument('-partition',  default='',       help="slurm_pbs partition")
     p_command.add_argument('-rs',         default='3',        help="Flag indicating which restarts to regrid: 1 (upper air); 2 (surface); 3 (both)", choices=['1','2','3'])
 
     # Parse using parse_known_args so we can pass the rest to the remap scripts
@@ -100,11 +97,11 @@ def get_answers_from_command_line(cml):
    answers["output:shared:out_dir"]    = os.path.abspath(cml.out_dir + '/')
    if  cml.merra2:
       init_merra2(answers)
-   else:   
+   else:
       answers["input:shared:bc_version"]   = cml.bcvin
       answers["input:surface:catch_model"] = cml.catch_model
       answers["input:shared:rst_dir"]      = os.path.abspath(cml.rst_dir + '/')
-      fvcore_info(answers) 
+      fvcore_info(answers)
       ogrid                            = cml.oceanin
       if ogrid == "CS":
          ogrid = answers["input:shared:agrid"]
@@ -144,7 +141,7 @@ def get_answers_from_command_line(cml):
 
    answers["output:air:agcm_import_rst"] = not cml.noagcm_import_rst
 
-   if cml.zoom: 
+   if cml.zoom:
       answers["input:surface:zoom"]    = cml.zoom
    else:
       # zoom_default fills 'input:shared:agrid'
@@ -163,7 +160,7 @@ def get_answers_from_command_line(cml):
    answers["slurm_pbs:account"]    = cml.account
    answers["slurm_pbs:qos"]        = cml.qos
    answers["slurm_pbs:partition"]  = cml.partition
-  
+
    return answers
 
 if __name__ == "__main__":
@@ -176,7 +173,7 @@ if __name__ == "__main__":
    with open("raw_command.yaml", "w") as f:
      yaml.dump(config, f)
 
-   config = get_config_from_answers(answers, config_tpl= True) 
+   config = get_config_from_answers(answers, config_tpl= True)
    with open("params_from_command.yaml", "w") as f:
      yaml.dump(config, f)
 

--- a/pre/remap_restart/remap_questions.py
+++ b/pre/remap_restart/remap_questions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # remap_restarts package:
-#   interactive questionary to create a yaml configuration file (remap_params.yaml) and 
+#   interactive questionary to create a yaml configuration file (remap_params.yaml) and
 #   a matching command line argument string (remap_restarts.CMD)
 #
 #
@@ -37,10 +37,7 @@ def echo_bcs(x,opt):
 
 def default_partition(x):
    if x['slurm_pbs:qos'] == 'debug':
-      if (BUILT_ON_SLES15):
-         x['slurm_pbs:partition'] = 'scutest'
-      else:
-         x['slurm_pbs:partition'] = 'compute'
+      x['slurm_pbs:partition'] = 'compute'
       return False
    return True
 
@@ -50,7 +47,7 @@ def validate_merra2_time(text):
       if hh in ['03','09','15','21']:
          return True
       else:
-         return False 
+         return False
    else:
      return False
 def SITE_MERRA2(x):
@@ -176,7 +173,7 @@ def ask_questions():
         {
             "type": "select",
             "name": "output:shared:stretch",
-            "message": message_stretch, 
+            "message": message_stretch,
             "choices": choices_stretch[1:3],
             "when": lambda x : x['output:shared:stretch'],
         },
@@ -185,7 +182,7 @@ def ask_questions():
             "type": "select",
             "name": "output:shared:agrid",
             "message": "Select resolution of SG001 grid for new restarts: \n",
-            "choices": choices_res_SG001, 
+            "choices": choices_res_SG001,
             "when": lambda x : x.get('output:shared:stretch') == 'SG001',
         },
 
@@ -193,7 +190,7 @@ def ask_questions():
             "type": "select",
             "name": "output:shared:agrid",
             "message": "Select resolution of SG002 grid for new restarts: \n",
-            "choices": choices_res_SG002, 
+            "choices": choices_res_SG002,
             "when": lambda x : x.get('output:shared:stretch') == 'SG002',
         },
 
@@ -344,8 +341,8 @@ def ask_questions():
         {
             "type": "confirm",
             "name": "output:air:agcm_import_rst",
-            "message": f'''Remap agcm_import_rst (a.k.a. IAU) file needed for REPLAY runs? 
-                        (NOTE: Preferred method is to regenerate IAU file, 
+            "message": f'''Remap agcm_import_rst (a.k.a. IAU) file needed for REPLAY runs?
+                        (NOTE: Preferred method is to regenerate IAU file,
                                but IF requested, remapping will be performed.)''',
             "default": False,
             "when": lambda x: echo_level(x),
@@ -430,13 +427,13 @@ def ask_questions():
    answers['output:shared:out_dir'] = os.path.abspath(answers['output:shared:out_dir'])
 
    if answers.get('input:air:nlevel') : del answers['input:air:nlevel']
-   if answers["output:surface:remap"] and not answers["input:shared:MERRA-2"]:  
+   if answers["output:surface:remap"] and not answers["input:shared:MERRA-2"]:
       answers["input:surface:catch_model"] = catch_model(answers)
    answers["output:surface:remap_water"] = answers["output:surface:remap"]
    answers["output:surface:remap_catch"] = answers["output:surface:remap"]
    del answers["output:surface:remap"]
    if answers["input:shared:MERRA-2"] : answers["input:air:hydrostatic"] = True
- 
+
    return answers
 
 if __name__ == "__main__":


### PR DESCRIPTION
The remap_restarts in v12 had said "if SLES15, use scutest as SLURM partition". Well, not everyone has access to that. Probably at the time when that code got in, SLES15 wasn't quite GA. But now it is, so we move back to compute.

I'll add @weiyuan-jiang as a reviewer, but I think this is good as all I did was remove that bit.