### PR TITLE
Fix N2O bug in remap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added remapping for GEOS-IT restarts 
-- Added new res C1120 
+- Added remapping for GEOS-IT restarts
+- Added new res C1120
 - NOTE: If running on SLES15 remap tests will not be zero diff for GOCART RST but are zero diff for all other
 
 ### Changed
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update ESMF CMake target to `ESMF::ESMF`
 
 ### Fixed
+
+- Correct bug in `remap_restarts.py` where `N2O` was added as `N20`
 
 ### Removed
 

--- a/pre/remap_restart/bin2nc_merra2_gocart.yaml
+++ b/pre/remap_restart/bin2nc_merra2_gocart.yaml
@@ -6,7 +6,7 @@ variables:
        - lev
        - lat
        - lon
-  - short_name: N20
+  - short_name: N2O
     long_name: nitrous_oxide_volume_mixing_ratio
     units: 'mol mol-1'
     dimension:

--- a/pre/remap_restart/bin2nc_merra2_pchem.yaml
+++ b/pre/remap_restart/bin2nc_merra2_pchem.yaml
@@ -6,7 +6,7 @@ variables:
        - lev
        - lat
        - lon
-  - short_name: N20
+  - short_name: N2O
     long_name: nitrous_oxide_volume_mixing_ratio
     units: 'mol mol-1'
     dimension:


### PR DESCRIPTION
Per @briardew, the remap scripts were making an N<sub>20</sub> (icosanitrogen) field in `pchem` and `gocart` when remapping from MERRA2 instead of N<sub>2</sub>O (nitrous oxide). This fixes that.

ETA: Fun with science. Apparently N<sub>8</sub> would be...[unpleasant](https://en.wikipedia.org/wiki/Octaazacubane). I shudder to think what N<sub>20</sub> (probably called fullerene-N20) would be like. 