### PR TITLE
Bugfix/jstassi/#114 g5fcst stats pl

### DIFF
--- a/post/g5fcst_stats.pl
+++ b/post/g5fcst_stats.pl
@@ -400,8 +400,8 @@ sub init {
     # initial fcst hour and offset
     #-----------------------------
     unless ($ihh) {
-        if ($expid eq "a_flk_04") { $ihh =  0 }
-        else                      { $ihh = 21 }
+        if (defined($expid) and $expid eq "a_flk_04") { $ihh =  0 }
+        else                                          { $ihh = 21 }
     }
     if ($ihh == 0 or $ihh == 6 or $ihh == 12 or $ihh == 18) { $offset = 0 }
     if ($ihh == 3 or $ihh == 9 or $ihh == 15 or $ihh == 21) { $offset = 3 }
@@ -755,8 +755,8 @@ sub submit_calcjob {
       $qos     = "#SBATCH --qos=dastest";        # wired for now since only way to use CAS
       $partition = "#SBATCH --partition=preops"; # wired for now since only way to use CAS
     } else {
-      $mynodes = "hasw";
-      $ntspn   = 24;
+      $mynodes = "mil";
+      $ntspn   = 120;
       $qos     = "";
       $partition = "";
 #     $qos     = "#SBATCH --qos=dastest";        # wired for now since only way to use HASW
@@ -855,7 +855,6 @@ sub submit_archivejob {
     my ($yyyy, $mm, $dd, $logdir, $logfile1, $logfile2, $pdir);
     my ($jobname, $jobdate, $jobfile_0, $jobfile, $jobtype);
     my ($cmd, $deps, $dependFLG, $jobIDline, $jobID);
-    my ($mynodes);
 
     # input arguments
     #----------------
@@ -1066,7 +1065,7 @@ OPTIONS [defaults in brackets]
     -nxonly            calculate stats of 2d Nx collection only (yes/no) 
                        [no by default] 
 
-    -nodes nodesname   specify nodes (e.g., sky, hasw, or cas)
+    -nodes nodesname   specify nodes (e.g., sky, cas, or mil)
     -das               check for DAS hidden files before attempting to fetch files
                        and set no prompt; requires \$FVHOME environment variable;
 

--- a/pre/NSIDC-OSTIA_SST-ICE_blend/read_Reynolds.F90
+++ b/pre/NSIDC-OSTIA_SST-ICE_blend/read_Reynolds.F90
@@ -1,19 +1,17 @@
 !
-      SUBROUTINE read_Reynolds(ncFileName, maskFileName, NLAT, NLON, LAT, LON, &
-                               SST, ICE, MASK, myUNDEF)
+      SUBROUTINE read_Reynolds(ncFileName, NLAT, NLON, LAT, LON, &
+                               SST, ICE, myUNDEF)
 !---------------------------------------------------------------------------
           USE netcdf
           IMPLICIT NONE
 
           CHARACTER (LEN = *),             INTENT(IN)    :: ncFileName
-          CHARACTER (LEN = *),             INTENT(IN)    :: maskFileName
           INTEGER,                         INTENT(IN)    :: NLAT, NLON
           REAL,                            INTENT(IN)    :: myUNDEF
           REAL, DIMENSION(NLAT),           INTENT(OUT)   :: LAT
           REAL, DIMENSION(NLON),           INTENT(OUT)   :: LON
           REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: SST
           REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: ICE
-          REAL, DIMENSION(NLON,NLAT),      INTENT(OUT)   :: MASK
 
 ! GET TO KNOW THESE BY ncdump -h
           REAL, PARAMETER :: sst_FillValue       = -999
@@ -22,10 +20,9 @@
           REAL, PARAMETER :: ice_FillValue       = -999
           REAL, PARAMETER :: ice_offset          =  0.0
           REAL, PARAMETER :: ice_scale_factor    =  0.01
-
           
 ! netCDF ID for the file and data variable.
-          INTEGER :: ncid, varid1, varid2, varid3, varid4, varid_mask
+          INTEGER :: ncid, varid1, varid2, varid3, varid4
 !         INTEGER :: iLON
 !         REAL    :: dLon
 !---------------------------------------------------------------------------
@@ -66,14 +63,6 @@
               ICE = myUNDEF
           ENDWHERE
 
-! .....................................................................
-! Read a land sea mask
-
-          print*, 'Reading mask from: ', maskFileName
-          CALL check( nf90_open(maskFileName, nf90_nowrite, ncid))
-          CALL check( nf90_inq_varid(ncid, "lsmaski", varid_mask))
-          CALL check( nf90_get_var(ncid, varid_mask, MASK))
-          CALL check( nf90_close(ncid))
 ! .....................................................................
 
 ! Reynolds has lon: (0, 360). 


### PR DESCRIPTION
Updated g5fcst_stats.pl to remove reference to Haswell nodes and to send job to milan nodes if the script is run on milan nodes.