### PR TITLE
Fix issue with movestat and multi-month seasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue with `movestat` which only allowed single-month seasons
+
 ### Removed
 
 ### Deprecated

--- a/plots/movestat
+++ b/plots/movestat
@@ -32,7 +32,7 @@ else  # Interactive Job
 # ------------------------------------
    if(! -e ~/.WEBSERVER ) then
 SERVER:
-     set server = NULL 
+     set server = NULL
      echo " "
      echo "Enter WEB Server to use:  train"
      echo "                          polar"
@@ -173,9 +173,7 @@ echo " "
          if( $season == 'NULL' ) then
            set files = `/bin/ls -1 *stats*gif`
            set fname = `echo $files[1] | cut -d. -f1`
-           set fsize = `echo $fname | awk '{print length($0)}'`
-             @ fsize = $fsize - 2
-          set season = `echo $fname | cut -b${fsize}-`
+           set season = `echo $fname | sed 's/.*_//g'`
          endif
          ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/corcmp
          echo Syncing ${season} Files from $pltdir/corcmp to $webid@${server}:${www}/${webdir}/${season}/corcmp
@@ -190,9 +188,7 @@ echo " "
              if( $season == 'NULL' ) then
                set files = `/bin/ls -1 *stats*gif`
                set fname = `echo $files[1] | cut -d. -f1`
-               set fsize = `echo $fname | awk '{print length($0)}'`
-                 @ fsize = $fsize - 2
-              set season = `echo $fname | cut -b${fsize}-`
+               set season = `echo $fname | sed 's/.*_//g'`
              endif
              ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/$DSC
              echo Syncing ${season} Files from $pltdir/$DSC to $webid@${server}:${www}/${webdir}/${season}/$DSC
@@ -210,9 +206,7 @@ echo " "
              if( $season == 'NULL' ) then
                set files = `/bin/ls -1 *stats*gif`
                set fname = `echo $files[1] | cut -d. -f1`
-               set fsize = `echo $fname | awk '{print length($0)}'`
-                 @ fsize = $fsize - 2
-              set season = `echo $fname | cut -b${fsize}-`
+               set season = `echo $fname | sed 's/.*_//g'`
              endif
              ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/$DSCS[1].$DSC
 


### PR DESCRIPTION
As found by @michellefrazer, she had plots with names like:
```
GCMv12rc12_GCMv12rc12_stats2_hght_rmscmp_AMPLITUDE_EUR_z_JUL-AUG-SEP-OCT
```
But when `movestat` ran, on polar things were in folders like `OCT`.

The issue is that the script assumed things would always be in three-letter "seasons". This PR makes a change so that the "season" is everything after the last underscore. So instead of `OCT` it is `JUL-AUG-SEP-OCT`.

NOTE: This has been tested by @michellefrazer, but it should probably be tested in experiments with a single-month "season".