### PR TITLE
Updates to quickstat plotting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issues keeping zonal mean plots from working when experiments had different levels/times
+
 ### Removed
 
 ### Deprecated

--- a/plots/fcst/setup_statd
+++ b/plots/fcst/setup_statd
@@ -256,6 +256,7 @@ say 'Opening Files for EXP: 'k
 * ------------------------------------------------------------
      if( ctdim < mtdim )
          mtdim = ctdim
+      tdimfile = cfile
      endif
 
 * Find Master Time Frequency (largest) among Experiment Files
@@ -271,7 +272,16 @@ say '  Current ZDIM: 'czdim'  Master ZDIM: 'mzdim
 say '  Current TDIM: 'ctdim'  Master TDIM: 'mtdim
 say '  Current TINC: 'ctinc'  Master TINC: 'mtinc
 say '  Current FILE: 'cfile'  Master TINCFILE: 'tincfile
+say '  Current FILE: 'cfile'  Master TDIMFILE: 'tdimfile
 say '  Current FILE: 'cfile'  Master ZMINFILE: 'zminfile
+
+if ( k = 0 )
+   'run setenv "FILE_CTL"    'cfile
+else
+   'run setenv "FILE_EXP"    'cfile
+endif
+
+say 'file 'k' : 'cfile
 
 say ' '
 say 'Closing files for Exp: 'k
@@ -306,6 +316,7 @@ say ' '
 'run setenv "SYSCMP_TDIM" 'mtdim
 'run setenv "SYSCMP_TINC" 'mtinc
 'run setenv "TINCFILE"    'tincfile
+'run setenv "TDIMFILE"    'tdimfile
 'run setenv "ZMINFILE"    'zminfile
 
 *******************************************************

--- a/plots/grads_util/corcmp_plot.gs
+++ b/plots/grads_util/corcmp_plot.gs
@@ -1033,11 +1033,11 @@ endwhile
 
 '!/bin/mkdir -p 'SOURCE'/corcmp'
 
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_corcmp_'reg'_'level'_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_corcmp_'reg'_'level'_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_corcmp_'reg'_'level'_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 
 if( debug = "TRUE" )
     say "Hit ENTER for next plot"

--- a/plots/grads_util/corcmpz_plot.gs
+++ b/plots/grads_util/corcmpz_plot.gs
@@ -236,22 +236,67 @@ say 'Months Used in Forecasts: 'months
 
 * Define TOPLEV, NDAY and NDAYMAX across ALL Experiments
 * ------------------------------------------------------
- toplev  = 0
- ndaymax = 999
-       m = 0
+toplev  = 0
+ndaymax = 999
+
+say 'determine experiment with largest top level'
+mexp = 1
+while ( mexp <= mexps )
+    say 'mexp: 'mexp
+    n   = filebeg
+    n.mexp = n + mexp*numfiles
+'set dfile 'n.mexp
+'getinfo zdim'
+    zdim = result
+    'set z 'zdim
+    'getinfo level'
+        level = result
+            if( level > toplev )
+                 toplev = level
+            endif
+mexp = mexp + 1
+endwhile
+say 'exp with largest top level: 'mexp-1
+
+say 'find smallest common level between that experiment and control'
+    mexp = mexp-1
+    m    = 0
+    n    = filebeg
+    n.m  = n + m*numfiles
+'set dfile 'n.m
+'getinfo zdim'
+    zdim_ctl = result
+    i = zdim_ctl
+while( i > 0 )
+    'set z 'i
+    'getinfo level'
+        level_ctl = result
+    'set dfile 'n.mexp
+    'getinfo zdim'
+        zdim_exp = result
+        j = zdim_exp
+while( j > 0 )
+    'set z 'j
+    'getinfo level'
+         level_exp = result
+    if ( level_exp = level_ctl )
+        toplev = level_ctl
+        j = 0
+        i = 0
+    else
+        j = j-1
+    endif
+endwhile
+i = i-1
+'set dfile 'n.m
+endwhile
+say 'final top level: 'toplev
+
+m = 0
 while( m<=mexps )
             n   = filebeg
             n.m = n + m*numfiles
 'set dfile 'n.m
-
-'getinfo zdim'
-         zdim = result
-        'set z 'zdim
-        'getinfo level'
-                 level = result
-             if( level > toplev )
-                 toplev = level
-             endif
 
 'run getinfo tinc'
              tinc = result
@@ -347,7 +392,6 @@ say '  m: 'm'  dfile: 'd.m'  tbeg: 'tbeg.m'  tdim: 'tdim.m
 m = m+1
 endwhile
 
-
 say 'Initialize zaved and zvard ...'
    m = 0
 while( m<=mexps )
@@ -376,7 +420,7 @@ while ( n  <= fileend )
 'set lev 1000 'toplev
 'set t  'tbeg.m' 'tdim.m
  toffset = 1-toffset.n.m
-*say 'dfile 'd.m'  tbeg: 'tbeg.m'  tend: 'tdim.m'  toffset: 'toffset'  'field'cor'n.m' = 'field'cor.'n.m'(t+'toffset')'
+say 'dfile 'd.m'  tbeg: 'tbeg.m'  tend: 'tdim.m'  toffset: 'toffset'  'field'cor'n.m' = 'field'cor.'n.m'(t+'toffset')'
 
 'define 'field'cor'n.m' = 'field'cor.'n.m'(t+'toffset')'
 n = n + 1
@@ -398,7 +442,7 @@ while ( n  <= fileend )
 'set t  'tbeg.m' 'tdim.m
 'define     q'm' = 'field'cor'n.m
 'define z'n'e'm' = 0.5*log( (1+ q'm')/(1- q'm'+5.0e-6) )'
-*say '   DFILE: 'n.m'   Defined q'm' and z'n'e'm
+say '   DFILE: 'n.m'   Defined q'm' and z'n'e'm
 n = n + 1
 endwhile
 m = m + 1
@@ -414,7 +458,7 @@ while ( n  <= fileend )
 
 * Set Proper Time Domain
 * ----------------------
-'set dfile 'm
+'set dfile '1
 'sett -q'
 'getinfo tinc'
          tinc1  = result
@@ -430,7 +474,7 @@ while ( n  <= fileend )
     'getinfo date'
              datemax1 = result
 
-'set dfile 'n
+'set dfile 'd.m
 'sett -q'
 'getinfo tinc'
          tinc2  = result
@@ -447,9 +491,9 @@ while ( n  <= fileend )
              datemax2 = result
 
 if( tinc1 >= tinc2 )
-    timefile.m = m
+    timefile.m = 1
 else
-    timefile.m = n
+    timefile.m = d.m
 endif
 
 if( datemin1 <= datemin2 )
@@ -465,9 +509,9 @@ else
 endif
      tdim.m = tmax - tmin + 1
 
-*say 'm: 'm'  tmin1: 'tmin1'  tmin2: 'tmin2'  tmin.m: 'tmin.m
-*say 'm: 'm'  tmax1: 'tmax1'  tmax2: 'tmax2'  tmax.m: 'tmax.m
-*say 'm: 'm'  tdim.m: 'tdim.m
+say 'm: 'm'  tmin1: 'tmin1'  tmin2: 'tmin2'  tmin.m: 'tmin.m
+say 'm: 'm'  tmax1: 'tmax1'  tmax2: 'tmax2'  tmax.m: 'tmax.m
+say 'm: 'm'  tdim.m: 'tdim.m
 
 * ----------------------
 
@@ -477,15 +521,12 @@ endif
 'define ctl = 'field'cor'n
 *say '   DFILE: 'n'  CTL defined for TBEG = 'tbeg.0' to TEND: 'tdif.0
 
-'define dum  = 'field'cor'n.m
-*say   '   DFILE: 'n.m'  DUM defined for TBEG = 'tbeg.0' to TEND: 'tdif.0
-
 if( m = 0 )
-*   say 'Computing DumDiff for EXP: 'm'   File: 'ddif.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
-   'define dumdiff = dum'
+    say 'Computing DumDiff for EXP: 'm'   File: 'ddif.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
+   'define dumdiff = 'field'cor'n.m
 else
     say 'Computing DumDiff in makezdif2 for EXP: 'm'   File: 'n.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
-   'makezdif2 -q1 dum -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum'
+   'makezdif2 -q1 'field'cor'n.m' -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum'
 endif
 
 'set dfile 'timefile.m
@@ -507,7 +548,7 @@ while( m<=mexps )
 while ( n <= fileend )
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define  zave'm' =  zave'm' +  z'n'e'm
@@ -546,7 +587,7 @@ while( m<=mexps )
 while ( n <= fileend )
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define  zvar'm' =  zvar'm' + pow(  z'n'e'm'- zave'm',2 )'
@@ -575,7 +616,6 @@ m = m + 1
 endwhile
 *pull flag
 
-
 * Compute Fisher Mean
 * -------------------
 say ' Compute Fisher Mean rave ...'
@@ -584,14 +624,13 @@ while( m<=mexps )
         n  = filebeg
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define rave'm' = (exp(2*zave'm')-1) / (exp(2*zave'm')+1)'
 m = m + 1
 endwhile
 *pull flag
-
 
 * Copmute Confidence Intervals for Two-Tailed Students T-Test Distribution
 * ------------------------------------------------------------------------
@@ -650,12 +689,12 @@ while( m<=mexps )
 m = m + 1
 endwhile
 
-
 ************************************************************************
 * if (1 = 0)
 * Plot Fisher Mean for Experiments
 * --------------------------------
 say '  Plot Fisher Mean for Experiments'
+
 'getinfo year'
          year = result
 'getinfo date'
@@ -667,8 +706,8 @@ while( m<=mexps )
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
 'set dfile 'timefile.m
-*'set t 'tmin.m' 'tmax.m
-'set t 'tbeg.m' 'tdif.m
+'set t 'tmin.m' 'tmax.m
+*'set t 'tbeg.m' 'tdif.m
 'set lev 1000 'toplev
 
 'set vpage off'
@@ -706,11 +745,11 @@ endif
 say 'EXP'm'  Field: 'name'  Region: 'region
 
 '!/bin/mkdir -p 'SOURCE'/corcmp'
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats_'label'_corcmp_'reg'_z_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats_'label'_corcmp_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats_'label'_corcmp_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 if( debug = "TRUE" )
     say "Hit ENTER for next plot"
     pull flag
@@ -722,7 +761,6 @@ endwhile
 *endif
 
 ************************************************************************
-
 
 * Plot Difference plus Significance
 * ---------------------------------
@@ -782,7 +820,22 @@ say 'Computing makezdif3 data for EXP: 'm'   File: 'mfile'  xpos: 'xpos'  Region
 
 * Define New Variables for Montage Plots
 * -------------------------------------
+
+'set dfile 'mfile
+'getinfo zdim'
+zdim_m = result
+
 'set dfile 'timefile.m
+'getinfo zdim'
+zdim_0 = result
+
+if( zdim_0 > zdim_m )
+    smallfile = mfile
+else
+    smallfile = timefile.m
+endif
+
+'set dfile 'smallfile
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 
@@ -815,7 +868,6 @@ say 'Computing makezdif3 data for EXP: 'm'   File: 'mfile'  xpos: 'xpos'  Region
 'define sigdiff99 = maskm99 + maskp99'
 'define sigdiff99p99 = maskm99p99 + maskp99p99'
 
-
 * Find maximum value of critical sigdiff across all levels and times
 * ------------------------------------------------------------------
 if( toplev <= 1 )
@@ -837,7 +889,7 @@ while( loop <= loopdim )
            if( loop = 2 ) ; levmin = 10  ; loopflag = "2" ; endif
            if( loop = 3 ) ; levmin = 1   ; loopflag = "3" ; endif
 
-'set dfile 'timefile.m
+'set dfile 'smallfile
 'set t 'tbeg.m' 'tdif.m
 'set lev 1000 'levmin
 
@@ -1100,11 +1152,11 @@ dcintx = dcint * 100
 say 'EXP'm'  Field: 'name'  Region: 'region
 
 '!/bin/mkdir -p 'SOURCE'/corcmp'
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_corcmp_'reg'_z_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_corcmp_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_corcmp_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 
 if( debug = "TRUE" )
     say "Hit ENTER for next plot"

--- a/plots/grads_util/corcmpz_plot.gs
+++ b/plots/grads_util/corcmpz_plot.gs
@@ -1082,24 +1082,37 @@ endif
  clevm = -1 * dcint + min_thickness
  clevp = min_thickness
 
-* Fill 95% confidence
+* Fill difference
 * -------------------------------
+'define plotdif = 1000 * ravediff'
  'set gxout grfill'
  'set clevs 'clevs
 *'set ccols 159 157 155 147 144 137 136 134 132 130 -1 120 121 122 123 124 125 126 127 128 129'
  'set ccols 59 57 55 47 44 37 36 34 32 30 -1 20 21 22 23 24 25 26 27 28 29'
- ' d sigdiff95 '
+ ' d plotdif'
  ' cbarn -xmid 6 -snum 0.70 -ndot 1'
 
-* Fill 99% dotted
+* Fill 95% dotted
 * -------------------------------
  'set csmooth on'
  'set gxout shade2'
  'set clevs 'clevm
  'set ccols 200 -1'
+ ' d sigdiff95 '
+ 'set clevs 'clevp
+ 'set ccols -1 200'
+ ' d sigdiff95 '
+ ' set csmooth off'
+
+* Fill 99% diag down
+* -------------------------------
+ 'set csmooth on'
+ 'set gxout shade2'
+ 'set clevs 'clevm
+ 'set ccols 150 -1'
  ' d sigdiff99 '
  'set clevs 'clevp
- 'set ccols -1 200' 
+ 'set ccols -1 150' 
  ' d sigdiff99 '
  ' set csmooth off'
 
@@ -1131,7 +1144,7 @@ dcintx = dcint * 100
 
 'set  strsiz .132'
 'draw string 6.0 8.15 'expdsc.m' - 'expdsc.0' ('numfiles')'
-'draw string 6.0 7.90 ACORR Difference (x10`a-3`n) >95% (Filled) >99% (Dotted) >99.99% (Hatched)'
+'draw string 6.0 7.90 ACORR Difference (x10`a-3`n) >95% (Dotted) >99% (Diag) >99.99% (Hatched)'
 'set  strsiz .125'
 'draw string 6.0 7.65 'name' 'region
 'set  strsiz .12'

--- a/plots/grads_util/makezdif2.gs
+++ b/plots/grads_util/makezdif2.gs
@@ -119,8 +119,18 @@ endif
 
 if( datemax1 >= datemax2 )
     tmax = tmax2
+    if ( timefile = file1 )
+       if ( tinc1 = 2*tinc2 )
+           tmax = (tmax - 1)/2 + 1
+       endif
+    endif
 else
     tmax = tmax1
+    if ( timefile = file2 )
+       if ( tinc2 = 2*tinc1 )
+           tmax = (tmax - 1)/2 + 1
+       endif
+    endif
 endif
      tdim = tmax - tmin + 1
 

--- a/plots/grads_util/rgbset.gs
+++ b/plots/grads_util/rgbset.gs
@@ -100,6 +100,9 @@ if( version != 'v2.0.1.oga.1' )
 * black dots
 'set tile 200 2 10 10 2 0'
 'set rgb 200 tile 200'
+* darker grey diag down
+'set tile 150 3 20 20 2 84'
+'set rgb 150 tile 150'
 * dark grey hatched
 'set tile 100 5 20 20 2 87'
 'set rgb 100 tile 100'

--- a/plots/grads_util/rmscmp_plot.gs
+++ b/plots/grads_util/rmscmp_plot.gs
@@ -1191,11 +1191,11 @@ endwhile
     if( rms = 3 ) ; rms_label = '_AMPLITUDE'  ; endif
     if( rms = 4 ) ; rms_label = '_PHASE'      ; endif
 
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_rmscmp'rms_label'_'reg'_'level'_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_rmscmp'rms_label'_'reg'_'level'_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/stats_'label'_rmscmp'rms_label'_'reg'_'level'_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 
 if( debug = "TRUE" )
     say "Hit ENTER for next plot"

--- a/plots/grads_util/rmscmpz_plot.gs
+++ b/plots/grads_util/rmscmpz_plot.gs
@@ -1218,34 +1218,37 @@ endif
  clevm = -1 * dcint + min_thickness
  clevp = min_thickness
 
-* Fill dotted 90% patterns
+* Fill difference
 * -------------------------------
-*'set csmooth on'
-*'set gxout shade2'
-*'set clevs 'clevs
-*'set ccols 259 257 255 247 244 237 236 234 232 230 -1 220 221 222 223 224 225 226 227 228 229'
-*' d sigdiff90 '
-*' d maskout(sigdiff90,abs(sigdiff90)-'min_thickness')'
-*' set csmooth off'
-
-* Fill 95% confidence
-* -------------------------------
+'define plotdif = 1000 * ravediff'
  'set gxout grfill'
  'set clevs 'clevs
 *'set ccols 159 157 155 147 144 137 136 134 132 130 -1 120 121 122 123 124 125 126 127 128 129'
  'set ccols 59 57 55 47 44 37 36 34 32 30 -1 20 21 22 23 24 25 26 27 28 29'
- ' d sigdiff95 '
+ ' d plotdif'
  ' cbarn -xmid 6 -snum 0.70 -ndot 1'
 
-* Fill 99% dotted
+* Fill 95% dotted
 * -------------------------------
  'set csmooth on'
  'set gxout shade2'
  'set clevs 'clevm
  'set ccols 200 -1'
+ ' d sigdiff95 '
+ 'set clevs 'clevp
+ 'set ccols -1 200'
+ ' d sigdiff95 '
+ ' set csmooth off'
+
+* Fill 99% diag down
+* -------------------------------
+ 'set csmooth on'
+ 'set gxout shade2'
+ 'set clevs 'clevm
+ 'set ccols 150 -1'
  ' d sigdiff99 '
  'set clevs 'clevp
- 'set ccols -1 200' 
+ 'set ccols -1 150'
  ' d sigdiff99 '
  ' set csmooth off'
 
@@ -1283,7 +1286,7 @@ dcintx = dcint * 100
 
 'set  strsiz .132'
 'draw string 6.0 8.15 'expdsc.m' - 'expdsc.0' ('numfiles')'
-'draw string 6.0 7.90 'rms_label' (x10`a-3`n) >95% (Filled) >99% (Dotted) >99.99% (Hatched)'
+'draw string 6.0 7.90 'rms_label' (x10`a-3`n) >95% (Dotted) >99% (Diag) >99.99% (Hatched)'
 
 'set  strsiz .125'
 'draw string 6.0 7.65 'name' 'region

--- a/plots/grads_util/rmscmpz_plot.gs
+++ b/plots/grads_util/rmscmpz_plot.gs
@@ -252,22 +252,67 @@ say 'Months Used in Forecasts: 'months
 
 * Define TOPLEV, NDAY and NDAYMAX across ALL Experiments
 * ------------------------------------------------------
- toplev  = 0
- ndaymax = 999
-       m = 0
+toplev  = 0
+ndaymax = 999
+
+say 'determine experiment with largest top level'
+mexp = 1
+while ( mexp <= mexps )
+    say 'mexp: 'mexp
+    n   = filebeg
+    n.mexp = n + mexp*numfiles
+'set dfile 'n.mexp
+'getinfo zdim'
+    zdim = result
+    'set z 'zdim
+    'getinfo level'
+        level = result
+            if( level > toplev )
+                 toplev = level
+            endif
+mexp = mexp + 1
+endwhile
+say 'exp with largest top level: 'mexp-1
+
+say 'find smallest common level between that experiment and control'
+    mexp = mexp-1
+    m    = 0
+    n    = filebeg
+    n.m  = n + m*numfiles
+'set dfile 'n.m
+'getinfo zdim'
+    zdim_ctl = result
+    i = zdim_ctl
+while( i > 0 )
+    'set z 'i
+    'getinfo level'
+        level_ctl = result
+    'set dfile 'n.mexp
+    'getinfo zdim'
+        zdim_exp = result
+        j = zdim_exp
+while( j > 0 )
+    'set z 'j
+    'getinfo level'
+         level_exp = result
+    if ( level_exp = level_ctl )
+        toplev = level_ctl
+        j = 0
+        i = 0
+    else
+        j = j-1
+    endif
+endwhile
+i = i-1
+'set dfile 'n.m
+endwhile
+say 'final top level: 'toplev
+
+m = 0
 while( m<=mexps )
             n   = filebeg
             n.m = n + m*numfiles
 'set dfile 'n.m
-
-'getinfo zdim'
-         zdim = result
-        'set z 'zdim
-        'getinfo level'
-                 level = result
-             if( level > toplev )
-                 toplev = level
-             endif
 
 'run getinfo tinc'
              tinc = result
@@ -448,7 +493,7 @@ while ( n  <= fileend )
 
 * Set Proper Time Domain
 * ----------------------
-'set dfile 'm
+'set dfile '1
 'sett -q'
 'getinfo tinc'
          tinc1  = result
@@ -464,7 +509,7 @@ while ( n  <= fileend )
     'getinfo date'
              datemax1 = result
 
-'set dfile 'n
+'set dfile 'd.m
 'sett -q'
 'getinfo tinc'
          tinc2  = result
@@ -481,9 +526,9 @@ while ( n  <= fileend )
              datemax2 = result
 
 if( tinc1 >= tinc2 )
-    timefile.m = m
+    timefile.m = 1
 else
-    timefile.m = n
+    timefile.m = d.m
 endif
 
 if( datemin1 <= datemin2 )
@@ -511,18 +556,20 @@ if( rms = 2 ) ; 'define ctl  =       'field'rmsbar'n     ; endif
 if( rms = 3 ) ; 'define ctl  =       'field'rmsdis'n     ; endif
 if( rms = 4 ) ; 'define ctl  =       'field'rmsdsp'n     ; endif
 
-if( rms = 0 ) ; 'define dum  =       'field'rms'n.m        ; endif
-if( rms = 1 ) ; 'define dum  =       'field'rmsran'n.m     ; endif
-if( rms = 2 ) ; 'define dum  =       'field'rmsbar'n.m     ; endif
-if( rms = 3 ) ; 'define dum  =       'field'rmsdis'n.m     ; endif
-if( rms = 4 ) ; 'define dum  =       'field'rmsdsp'n.m     ; endif
-
 if( m = 0 )
-*   say 'Computing DumDiff for EXP: 'm'   File: 'ddif.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
-   'define dumdiff = dum'
+    say 'Computing DumDiff for EXP: 'm'   File: 'ddif.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
+    if( rms = 0 ) ; 'define dumdiff  =       'field'rms'n.m        ; endif
+    if( rms = 1 ) ; 'define dumdiff  =       'field'rmsran'n.m     ; endif
+    if( rms = 2 ) ; 'define dumdiff  =       'field'rmsbar'n.m     ; endif
+    if( rms = 3 ) ; 'define dumdiff  =       'field'rmsdis'n.m     ; endif
+    if( rms = 4 ) ; 'define dumdiff  =       'field'rmsdsp'n.m     ; endif
 else
     say 'Computing DumDiff in makezdif2 for EXP: 'm'   File: 'n.m' for TBEG = 'tbeg.0' to TEND: 'tdif.0
-   'makezdif2 -q1 dum -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum'
+    if( rms = 0 ) ; 'makezdif2 -q1 'field'rms'n.m'    -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum' ; endif
+    if( rms = 1 ) ; 'makezdif2 -q1 'field'rmsran'n.m' -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum' ; endif
+    if( rms = 2 ) ; 'makezdif2 -q1 'field'rmsbar'n.m' -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum' ; endif
+    if( rms = 3 ) ; 'makezdif2 -q1 'field'rmsdis'n.m' -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum' ; endif
+    if( rms = 4 ) ; 'makezdif2 -q1 'field'rmsdsp'n.m' -file1 'd.m' -q2 zero    -file2   1 -ptop 'toplev' -name dum' ; endif
 endif
 
 'set dfile 'timefile.m
@@ -544,7 +591,7 @@ while( m<=mexps )
 while ( n <= fileend )
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define  zave'm' =  zave'm' +  z'n'e'm
@@ -583,7 +630,7 @@ while( m<=mexps )
 while ( n <= fileend )
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define  zvar'm' =  zvar'm' + pow(  z'n'e'm'- zave'm',2 )'
@@ -679,11 +726,14 @@ while( m<=mexps )
         n  = filebeg
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 'define zave'm'  = pow( abs( zave'm'  ),'irmsfact' )'
 'define zvar'm'  = pow( abs( zvar'm'  ),'irmsfact' )'
+'set dfile 'timefile.m
+'set t 'tmin.m' 'tmax.m
+'set lev 1000 'toplev
 'define zvard'm' = pow( abs( zvard'm' ),'irmsfact' )'
 m = m + 1
 endwhile
@@ -696,7 +746,7 @@ while( m<=mexps )
         n  = filebeg
         n.m = n + m*numfiles
         d.m = 1 + m*numfiles
-'set dfile 'timefile.m
+'set dfile 'd.m
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
                  'define rave'm'  = zave'm
@@ -805,11 +855,11 @@ say 'EXP'm'  Field: 'name'  Region: 'region
     if( rms = 3 ) ; rms_label = '_AMPLITUDE'  ; endif
     if( rms = 4 ) ; rms_label = '_PHASE'      ; endif
 
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.m'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 pause
 if( debug = "TRUE" )
     say "Hit ENTER for next plot"
@@ -885,7 +935,21 @@ say 'Computing makezdif3 data for EXP: 'm'   File: 'mfile'  xpos: 'xpos'  Region
 
 * Define New Variables for Montage Plots
 * -------------------------------------
+'set dfile 'mfile
+'getinfo zdim'
+zdim_m = result
+
 'set dfile 'timefile.m
+'getinfo zdim'
+zdim_0 = result
+
+if( zdim_0 > zdim_m )
+    smallfile = mfile
+else
+    smallfile = timefile.m
+endif
+
+'set dfile 'smallfile
 'set t 'tmin.m' 'tmax.m
 'set lev 1000 'toplev
 
@@ -940,7 +1004,7 @@ while( loop <= loopdim )
            if( loop = 2 ) ; levmin = 10  ; loopflag = "2" ; endif
            if( loop = 3 ) ; levmin = 1   ; loopflag = "3" ; endif
 
-'set dfile 'timefile.m
+'set dfile 'smallfile
 'set t 'tbeg.m' 'tdif.m
 'set lev 1000 'levmin
 
@@ -1251,11 +1315,11 @@ say 'EXP'm'  Field: 'name'  Region: 'region
     if( rms = 3 ) ; rms_label = '_AMPLITUDE'  ; endif
     if( rms = 4 ) ; rms_label = '_PHASE'      ; endif
 
-if( nday = ndaymax )
+*if( nday = ndaymax )
    'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months' -rotate 90 -density 100x100'
-else
-   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
-endif
+*else
+*   'run 'GEOSUTIL'/plots/grads_util/myprint2 -name 'SOURCE'/corcmp/'expdsc.0'_'expdsc.m'_stats'loopflag'_'label'_rmscmp'rms_label'_'reg'_z_'months'_'nday'DAY -rotate 90 -density 100x100'
+*endif
 pause
 
 if( debug = "TRUE" )


### PR DESCRIPTION
Code was updated to allow quickstat jobs (corcmp and syscmp) to produce zonal mean (latitude vs height) comparison plots when the compared experiments have different levels or different forecast lengths or different time increments.  Fixes for corcmp routines were to have EXP interpolate to CTL levels to define differences for zonal comparisons, look for shortest forecast length among all files, find the largest common pressure level to define as toplev, look for one time increment being 2x the other and adjust dimensions accordingly, and change the naming convention when the NDAY environment variable is set so that these plots are not seen as a different month by movestat. Fixes for syscmp routines were to identify the experiment with largest time increment and adjust dimension accordingly, find the largest common pressure level to define as toplev, and allow for limiting dimensions (fewer levels, shorter forecast length, etc.) to come from CTL or EXP.