### PR TITLE
Fix for movestat with files-with-dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update `movestat` to extract seasons in files with dots in the name
+
 ### Removed
 
 ### Deprecated

--- a/plots/movestat
+++ b/plots/movestat
@@ -172,8 +172,7 @@ echo " "
          cd $pltdir/corcmp
          if( $season == 'NULL' ) then
            set files = `/bin/ls -1 *stats*gif`
-           set fname = `echo $files[1] | cut -d. -f1`
-           set season = `echo $fname | sed 's/.*_//g'`
+           set season = `echo $files[1] | sed 's/.*_\([^_][^_]*\)\.[^.][^.]*$/\1/'`
          endif
          ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/corcmp
          echo Syncing ${season} Files from $pltdir/corcmp to $webid@${server}:${www}/${webdir}/${season}/corcmp
@@ -187,8 +186,7 @@ echo " "
              cd $pltdir/$DSC
              if( $season == 'NULL' ) then
                set files = `/bin/ls -1 *stats*gif`
-               set fname = `echo $files[1] | cut -d. -f1`
-               set season = `echo $fname | sed 's/.*_//g'`
+               set season = `echo $files[1] | sed 's/.*_\([^_][^_]*\)\.[^.][^.]*$/\1/'`
              endif
              ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/$DSC
              echo Syncing ${season} Files from $pltdir/$DSC to $webid@${server}:${www}/${webdir}/${season}/$DSC
@@ -205,8 +203,7 @@ echo " "
              cd $pltdir/$DSCS[1].$DSC
              if( $season == 'NULL' ) then
                set files = `/bin/ls -1 *stats*gif`
-               set fname = `echo $files[1] | cut -d. -f1`
-               set season = `echo $fname | sed 's/.*_//g'`
+               set season = `echo $files[1] | sed 's/.*_\([^_][^_]*\)\.[^.][^.]*$/\1/'`
              endif
              ssh $webid@${server} mkdir -p ${www}/${webdir}/${season}/$DSCS[1].$DSC
 


### PR DESCRIPTION
Per @michellefrazer:

> I'm having a new related issue where movestat is interpreting seasons wrong again.
> 
> With names like `GenCast-FP-1.0deg-e1_GenCast-FP-1.0deg-e1_stats_uwnd_corcmp_GLO_z_MAY.gif`, the season is interpreted as `P-1`.
> With names like `GenCast_FP_1.0deg_e1_GenCast_FP_1.0deg_e1_stats_uwnd_corcmp_GLO_z_MAY.gif`, the season is interpreted as `P_1`.
> 
> This PR was supposed to make the "season" everything after the last underscore, but it appears that somehow it is actually looking for a 3-character string before the first period.
> 
> I can of course avoid periods in my experiment names in future, but I'm wondering if the code should be changed to focus on the underscore instead of the period? Or look for the last period instead of the first one?

So I yelled at ChatGPT for a bit and this seems to do it.
