### PR TITLE
Updates to remove Python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
+
 ### Fixed
 
 ### Removed

--- a/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
+++ b/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
@@ -52,9 +52,9 @@ ecbuild_add_executable (
 set_target_properties(reynolds_QUART.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 if (USE_F2PY)
-   find_package(F2PY2)
-   if (F2PY2_FOUND)
-      esma_add_f2py2_module(read_ops_bcs
+   find_package(F2PY3)
+   if (F2PY3_FOUND)
+      esma_add_f2py3_module(read_ops_bcs
          SOURCES read_bin.f90
          DESTINATION bin
          INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}

--- a/pre/prepare_ocnExtData/CMakeLists.txt
+++ b/pre/prepare_ocnExtData/CMakeLists.txt
@@ -39,9 +39,9 @@ ecbuild_add_executable (
 set_target_properties(gen_forecast_bcs.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 if (USE_F2PY)
-   find_package(F2PY2)
-   if (F2PY2_FOUND)
-      esma_add_f2py2_module(read_sst_ice_bcs
+   find_package(F2PY3)
+   if (F2PY3_FOUND)
+      esma_add_f2py3_module(read_sst_ice_bcs
          SOURCES read_sst_ice_bin.f90
          DESTINATION bin
          INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}


### PR DESCRIPTION
It is time to remove `f2py2` support (aka Python2 support) in GEOS. This PR is one of a series where we convert `f2py2` builds to `f2py3`.

Note: There might be more needed Python2 → Python3 changes in scripts that _use_ this `f2py3` module, but I can say that the modules *build* so `f2py3` has no issue.