### PR TITLE
Compile TEM into OBJECT library to avoid race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Compile `TEM.F90` into an `OBJECT` library to avoid race condition when building
+
 ### Removed
 
 ### Deprecated
@@ -24,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for All-Times Transport Diagnostics
 - Fixed issues keeping zonal mean plots from working when experiments had different levels/times
 - Update `movestat` to extract seasons in files with dots in the name
-
 
 ## [2.1.10] - 2025-08-29
 

--- a/post/CMakeLists.txt
+++ b/post/CMakeLists.txt
@@ -28,8 +28,20 @@ ecbuild_add_executable (TARGET binarytile.x SOURCES binarytile.F90)
 ecbuild_add_executable (TARGET rs_numtiles.x SOURCES rs_numtiles.F90)
 ecbuild_add_executable (TARGET rs_vinterp.x SOURCES rs_vinterp.F90)
 ecbuild_add_executable (TARGET rs_vinterp_scm.x SOURCES rs_vinterp_scm.F90)
-ecbuild_add_executable (TARGET time_ave.x SOURCES time_ave.F TEM.F90 DEFINITIONS mpi)
-ecbuild_add_executable (TARGET Create_TEM_Diag.x SOURCES Create_TEM_Diag.F TEM.F90)
+
+# Because TEM is a bare subroutine (not in a module), we occasionally
+# hit a race condition. So we will compile it into an OBJECT library
+ecbuild_add_library(TARGET tem_lib SOURCES TEM.F90 TYPE OBJECT)
+
+# Link both executables against it
+ecbuild_add_executable(TARGET time_ave.x
+                       SOURCES time_ave.F
+                       LIBS tem_lib
+                       DEFINITIONS mpi)
+
+ecbuild_add_executable(TARGET Create_TEM_Diag.x
+                       SOURCES Create_TEM_Diag.F
+                       LIBS tem_lib)
 
 ecbuild_add_executable (TARGET stats.x SOURCES stats.F90)
 if (DISABLE_FIELD_WIDTH_WARNING)


### PR DESCRIPTION
Every so often, in CI we seem to hit a race condition with `TEM.F90`, e.g.:

https://app.circleci.com/pipelines/github/GEOS-ESM/MAPL/12807/workflows/ba162562-3e88-43c6-be0e-30e7645453da/jobs/125949

```
ld: CMakeFiles/Create_TEM_Diag.x.dir/Create_TEM_Diag.F.o: in function `MAIN__':
/root/project/GEOSgcm/src/Shared/@GMAO_Shared/@GEOS_Util/post/Create_TEM_Diag.F:176:(.text+0xd367): undefined reference to `tem_'
```

My only guess is that we are seeing a race condition where both `Create_TEM_Diag.x` and `time_ave.x` are both building `TEM.F90` at roughly the same time and we get a point where a partial `TEM.o` is not there? Not sure. But this should guarantee an order.