### PR TITLE
Make TEM a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make `TEM.F90` a module to try and avoid build race conditions
+
 ### Removed
 
 ### Deprecated

--- a/post/Create_TEM_Diag.F
+++ b/post/Create_TEM_Diag.F
@@ -1,4 +1,5 @@
       program  main
+      use tem_mod, only: TEM
       implicit none
 
 ! **********************************************************************
@@ -33,7 +34,7 @@
       character*256, allocatable ::  vname(:)
       character*256, allocatable :: vtitle(:)
       character*256, allocatable :: vunits(:)
-                                                                                                                     
+
       real,    allocatable :: TEM_VARS(:,:,:,:)
       real,    allocatable ::      lat(:)
       real,    allocatable ::      lon(:)
@@ -43,7 +44,7 @@
       integer, allocatable ::   yymmdd(:)
       integer, allocatable ::   hhmmss(:)
       integer, allocatable ::    kmvar(:)
-                                                                                                                     
+
       integer nargs, iargc
       character*256, allocatable ::   arg(:)
       character*256, allocatable :: fname(:)
@@ -132,7 +133,7 @@
 
       call gfio_open       ( trim(filename),1,id,rc )
       call gfio_diminquire ( id,im,jm,lm,ntime,nvars,ngatts,rc )
-                                                                                                                     
+
       TEM_NVARS = 7
 
       allocate ( lon(im) )
@@ -146,7 +147,7 @@
       allocate (  kmvar(nvars) )
       allocate ( vrange(2,nvars) )
       allocate ( prange(2,nvars) )
-                                                                                                                     
+
       call gfio_inquire ( id,im,jm,lm,ntime,nvars,
      .                    title,source,contact,undef,
      .                    lon,lat,lev,levunits,
@@ -187,7 +188,7 @@
       deallocate ( vrange )
       deallocate ( prange )
       deallocate ( TEM_VARS )
-                                                                                                                     
+
       enddo
 
 ! **********************************************************************

--- a/post/TEM.F90
+++ b/post/TEM.F90
@@ -1,4 +1,13 @@
-      subroutine TEM( TEM_VARS,im,jm,lm,TEM_NVARS,                          &
+module tem_mod
+
+   implicit none
+
+   private
+   public :: TEM
+
+contains
+
+subroutine TEM( TEM_VARS,im,jm,lm,TEM_NVARS,                          &
                       EXPID,lon,lat,lev,levunits,nymd,nhms,timinc,undef )
       implicit none
       character*6   date
@@ -88,7 +97,7 @@
 
 ! Read data from grads.fwrite: Data is written BOT (L=1) to TOP (L=LM)
 ! --------------------------------------------------------------------
- 
+
           ntime = 1
 
           print *
@@ -188,7 +197,7 @@
       allocate(  wstar2(jm,lm) )
       allocate(  wmean2(jm,lm) )
       allocate(  weddy2(jm,lm) )
-                                                                                                                                
+
       allocate(  upvp  (jm,LM)  )
       allocate(  upwp  (jm,LM)  )
       allocate(  dudp  (jm,LM)  )
@@ -233,7 +242,7 @@
 ! Compute Meridional Streamfunction
 ! ---------------------------------
       call stream ( vz,pl,jm,lm,strm,undef )
- 
+
       call make_psi ( uz,vz,thz,omg,upvpz,upwpz,vpthpz,pl,jm,lm,psi1,psi2,psim,epfy,epfz,epfdiv, &
                       undef,upvp,upwp,dudp,dudphi,psie,dfdphi,dfdp,vstar2,veddy,wstar2,wmean2,weddy2,plz,delp)
 
@@ -244,7 +253,7 @@
 ! Compute Residual Circulation using wmean2 from model data rather than wz from continuity
 ! ----------------------------------------------------------------------------------------
       call residual ( vz,vpthpz,thz,wmean2,pl,jm,lm,res,vstar,wstar,wmean,weddy,undef )
- 
+
 
 ! **********************************************************************
 ! ****               Write TEM_Diag Monthly Output File             ****
@@ -461,9 +470,12 @@
     ! ************************************************************************************************************
 
       SUBROUTINE  GLAWRT  (A, JM,LM, KTP, undef)
+      implicit none
+      integer  JM,LM,KTP
       real        A   (JM,LM)
       real*4      TEM (JM), undef
       logical defined
+      integer J,L
       DO  L=1,LM
           DO  J=1,JM
               if( defined(a(J,L),undef) ) then
@@ -488,7 +500,7 @@
       integer j,k,L,jm,lm
       real undef,dphi,a,g,pi,phi,pk0,H
       logical defined
-       
+
       real    th0(jm,lm),    th(jm,lm)
       real  upvp0(jm,lm),  upvp(jm,lm)
       real  upwp0(jm,lm),  upwp(jm,lm)
@@ -769,14 +781,14 @@
                phi = -pi/2 + (j-1)*dphi
           if( defined( dudp(j,L),undef)  .and. &
               defined( psie(j,L),undef)  .and. &
-              defined( upvp(j,L),undef) ) then 
+              defined( upvp(j,L),undef) ) then
                        epfy(j,L) = a*cos(phi)*( dudp(j,L)*psie(j,L) - upvp(j,L) )
           else
                        epfy(j,L) = undef
           endif
-          if( defined( dudphi(j,L),undef)  .and.& 
+          if( defined( dudphi(j,L),undef)  .and.&
               defined(   psie(j,L),undef)  .and. &
-              defined(   upwp(j,L),undef) ) then 
+              defined(   upwp(j,L),undef) ) then
                          epfz(j,L) = a*cos(phi)*( (f(j)-dudphi(j,L))*psie(j,L) - upwp(j,L) )
           else
                          epfz(j,L) = undef
@@ -799,7 +811,7 @@
       do L=1,lm
       do j=1,jm
           if( defined(   dfdp(j,L),undef)  .and. &
-              defined( dfdphi(j,L),undef) ) then 
+              defined( dfdphi(j,L),undef) ) then
                        epfdiv(j,L) = dfdphi(j,L) + dfdp(j,L)
           else
                        epfdiv(j,L) = undef
@@ -868,7 +880,7 @@
       implicit none
       integer j,k,L,jm,lm
       real pi,dp,a,g,const,phi,undef
-       
+
       real  v(jm,lm), v0(jm,lm)
       real  s(jm,lm)
       real p0(jm,lm),  p(jm,lm)
@@ -945,7 +957,7 @@
       integer j,k,L,jm,lm
       real pi,dp,a,g,H,ps,ts,rhos,z,phi,undef
       real airmw,runiv,cpd,rgas,akap, sum
-       
+
       real     v0(jm,lm),   v(jm,lm)
       real     w0(jm,lm),   w(jm,lm)
       real vpthp0(jm,lm), th0(jm,lm)
@@ -1004,7 +1016,7 @@
       rho0(j,L) = rhos*exp(-z/H)
       enddo
       enddo
-      
+
       do j=1,jm
       phi = -pi/2 + (j-1)*dp
       cosp(j) = cos(phi)
@@ -1178,7 +1190,7 @@
       use MAPL_ConstantsMod
       implicit none
       integer j,k,L,jm,lm
-       
+
       real     v0(jm,lm),    v(jm,lm)
       real     p0(jm,lm),    p(jm,lm)
       real      w(jm,lm), rho0(jm,lm)
@@ -1376,7 +1388,7 @@
       do j=2,jm-1
          phi = -pi/2 + (j-1)*dphi
          if( defined(stuff(j+1,L),undef)  .and. &
-             defined(stuff(j-1,L),undef) ) then 
+             defined(stuff(j-1,L),undef) ) then
              dqdphi(j,L) = ( stuff(j+1,L)-stuff(j-1,L) )/(a*cos(phi)*2*dphi)
          else
              dqdphi(j,L) = undef
@@ -1573,3 +1585,4 @@
 
       return
       end subroutine map1_cubic
+end module tem_mod

--- a/post/time_ave.F
+++ b/post/time_ave.F
@@ -3,6 +3,7 @@
       use ESMF
 
       use dynamics_lattice_module
+      use tem_mod, only: TEM
       implicit none
       type ( dynamics_lattice_type ) lattice
 


### PR DESCRIPTION
Every so often, in CI we seem to hit a race condition with `TEM.F90`, e.g.:

https://app.circleci.com/pipelines/github/GEOS-ESM/MAPL/12807/workflows/ba162562-3e88-43c6-be0e-30e7645453da/jobs/125949

```
ld: CMakeFiles/Create_TEM_Diag.x.dir/Create_TEM_Diag.F.o: in function `MAIN__':
/root/project/GEOSgcm/src/Shared/@GMAO_Shared/@GEOS_Util/post/Create_TEM_Diag.F:176:(.text+0xd367): undefined reference to `tem_'
```

My only guess is that we are seeing a race condition where both `Create_TEM_Diag.x` and `time_ave.x` are both building `TEM.F90` at roughly the same time and we get a point where a partial `TEM.o` is not there? Not sure.

So this PR makes `TEM.F90` a module so that hopefully CMake can do its thing and make dependencies which it can't do with a bare subroutine.