### PR TITLE
Update binarytile for scripting use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update `binarytile.F90` to open the text tile files as read-only and allow longer paths
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected an issue where tags like ":V" after cmp exps were resulting in "ctag" showing up in filenames and labels for some plots
 - Fixed incorrect labeling of model data as actual or climatological in some plots
 - Updated makplotz to prevent blank or fake zonal line plots from being created
+- Updated `test_remap_cases.yaml` to point to baselines consistent with v11
 
 ### Removed
 
@@ -39,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Edited gcmpost.script to move up the location of $SOURCE/plot/.quickplotrc to restore missing plots from landscape.list for some users.
-- Updated `test_remap_cases.yaml` to point to baselines consistent with v11
 
 ## [2.1.12] - 2026-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Removed
+
+### Deprecated
+
+## [2.1.14] - 2026-04-09
+
+### Fixed
+
 - Update `binarytile.F90` to open the text tile files as read-only and allow longer paths
 - Edited gcmpost.script to move up the location of $SOURCE/plot/.quickplotrc to restore missing plots from landscape.list for some users.
 - Corrected LWP plot command in portrait.script to only include LWP not CCWP
@@ -20,10 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect labeling of model data as actual or climatological in some plots
 - Updated makplotz to prevent blank or fake zonal line plots from being created
 - Updated `test_remap_cases.yaml` to point to baselines consistent with v11
-
-### Removed
-
-### Deprecated
 
 ## [2.1.13] - 2026-03-19
 

--- a/post/binarytile.F90
+++ b/post/binarytile.F90
@@ -14,18 +14,18 @@ Program binarytile
   integer            :: grid_info(2),status
   real, allocatable  :: AVR(:,:)
   real               :: DUMMY
-  character(len=128) :: NAME 
-  character(len=128) :: filenameIN 
-  character(len=128) :: filenameOUT
-  integer, parameter :: max_rec=2 
+  character(len=512) :: NAME
+  character(len=512) :: filenameIN
+  character(len=512) :: filenameOUT
+  integer, parameter :: max_rec=2
 
   call getarg(1,filenameIN)
-  if (filenameIN == "") filenameIN = 'input'
+  if (trim(filenameIN) == "") filenameIN = 'input'
   call getarg(2,filenameOUT)
-  if (filenameOUT == "") filenameOUT = 'output'
+  if (trim(filenameOUT) == "") filenameOUT = 'output'
 
-  open(unit=unitR, file=filenameIN, form='FORMATTED')
-  open(unit=unitW, file=filenameOUT,form='UNFORMATTED')
+  open(unit=unitR, file=trim(filenameIN),  form='FORMATTED',   action='READ')
+  open(unit=unitW, file=trim(filenameOUT), form='UNFORMATTED')
   !READ (unitR, *) NT, NPFAF
   !WRITE(unitW   ) NT, NPFAF
 


### PR DESCRIPTION
This pull request updates the `binarytile.F90` program to improve file handling and path support. The main improvements are ensuring input files are opened as read-only and increasing the maximum supported path length for file names.

**File handling improvements:**

* Changed the `open` statement for the input file in `binarytile.F90` to explicitly open files as read-only using the `action='READ'` flag, improving safety by preventing accidental modification of input files.
* Used `trim()` on filenames to remove trailing spaces when opening files and assigning default names, ensuring correct file access.

**Path length support:**

* Increased the character length of `NAME`, `filenameIN`, and `filenameOUT` variables from 128 to 512 to support longer file paths.