### PR TITLE
Migrate MAPL_BaseMod to MAPL_Constants in post/ files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `post/` files (`AI_prs2eta.F`, `gg2fv.F`, `era5_prs2eta.F`, `ec_prs2eta.F`, `gg2eta.F`, `mpi_util.F`, `ec_eta2fv.F`) from `use MAPL_BaseMod, only: MAPL_UNDEF` to `use MAPL_Constants, only: MAPL_UNDEF` (MAPL#4857)
 - Update `movestat` to allow for multiple seasons
 - Update `remap_restarts.py` to first ask about remapping from GEOS-IT, then ask about MERRA-2. Add detection of MERRA-2 path as well
 - Comprehensively updated aerosol plotting with added plots and features

--- a/post/AI_prs2eta.F
+++ b/post/AI_prs2eta.F
@@ -1467,7 +1467,7 @@ c -------------------------------
       subroutine put_fveta ( ps,dp,u,v,thv,q,phis,
      .                       im,jm,lm,nq,nymd,nhms,tag,ext,lonbeg,
      .                       timeinc,precision )
-      use MAPL_BaseMod, only: MAPL_UNDEF      
+      use MAPL_Constants, only: MAPL_UNDEF
       use MAPL_Constants
       use m_set_eta, only: set_eta
       implicit  none

--- a/post/ec_eta2fv.F
+++ b/post/ec_eta2fv.F
@@ -405,7 +405,7 @@ C **********************************************************************
       subroutine put_fvrst ( ps,dp,u,v,thv,q,phis,
      .                       im,jm,lm,nq,nymd,nhms,tag,ext,lonbeg,
      .                       timeinc,precision,dgrid,tvflag )
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use m_set_eta, only: set_eta
       implicit  none
 

--- a/post/ec_prs2eta.F
+++ b/post/ec_prs2eta.F
@@ -1758,7 +1758,7 @@ c -------------------------------
       subroutine put_fveta ( ps,dp,u,v,thv,q,phis,
      .                       im,jm,lm,nq,nymd,nhms,tag,ext,lonbeg,
      .                       timeinc,precision )
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use MAPL_Constants
       use m_set_eta, only: set_eta
       implicit  none

--- a/post/era5_prs2eta.F
+++ b/post/era5_prs2eta.F
@@ -1826,7 +1826,7 @@ c -------------------------------
       subroutine put_fveta ( ps,dp,u,v,thv,q,phis,
      .                       im,jm,lm,nq,nymd,nhms,tag,ext,lats,lons,
      .                       timeinc,precision,lattice )
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use MAPL_Constants
       use m_set_eta, only: set_eta
       use dynamics_lattice_module

--- a/post/gg2eta.F
+++ b/post/gg2eta.F
@@ -233,7 +233,7 @@ C **********************************************************************
       subroutine put_fveta ( ps,dp,u,v,thv,q,phis,
      .                       im,jm,lm,nq,nymd,nhms,tag,ext,lonbeg,
      .                       timeinc,precision )
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use m_set_eta, only: set_eta
       implicit  none
 

--- a/post/gg2fv.F
+++ b/post/gg2fv.F
@@ -541,7 +541,7 @@ C **********************************************************************
      .                       frland,frlandice,frlake,frocean,frseaice,
      .                       ts,im,jm,lm,nq,nymd,nhms,tag,ext,lonbeg,
      .                       timeinc,precision,dgrid,tvflag )
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use m_set_eta, only: set_eta
       implicit  none
 
@@ -987,7 +987,7 @@ c --------------------
       subroutine get_ncep_ts ( filename,ts,im,jm,nymd,nhms )
 c program to read ts from ncep surface analysis file
 c --------------------------------------------------
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       implicit none
       integer  im,jm,nymd,nhms
       real  ts(im,jm)

--- a/post/mpi_util.F
+++ b/post/mpi_util.F
@@ -713,7 +713,7 @@ C ****  lattice . Grid Lattice for MPI                              ****
 C ****  flag .... Character*(*) to do 'east' or 'west' only         ****
 C ****                                                              ****
 C **********************************************************************
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use dynamics_lattice_module
       implicit none
       type ( dynamics_lattice_type ) lattice
@@ -838,7 +838,7 @@ C ****  lattice . Grid Lattice for MPI                              ****
 C ****  flag .... Character*(*) to do 'north', 'south', or 'pole'   ****
 C ****                                                              ****
 C **********************************************************************
-      use MAPL_BaseMod, only: MAPL_UNDEF
+      use MAPL_Constants, only: MAPL_UNDEF
       use dynamics_lattice_module
       implicit none
       type ( dynamics_lattice_type ) lattice


### PR DESCRIPTION
## Summary

Migrates 7 `post/` files from `use MAPL_BaseMod, only: MAPL_UNDEF` to `use MAPL_Constants, only: MAPL_UNDEF`, as `MAPL_BaseMod` is being deleted in GEOS-ESM/MAPL#4857.

## Files changed

`AI_prs2eta.F`, `gg2fv.F`, `era5_prs2eta.F`, `ec_prs2eta.F`, `gg2eta.F`, `mpi_util.F`, `ec_eta2fv.F`

Closes #221
Part of GEOS-ESM/MAPL#4857