### PR TITLE
v12: Fix remap_restarts after merge

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,4 +36,5 @@ jobs:
     with:
       fixture-repo: GEOS-ESM/GEOSgcm
       fixture-ref: feature/sdrabenh/gcm_v12
+      load-fms: true
 

--- a/pre/remap_restart/remap_other_restarts.py
+++ b/pre/remap_restart/remap_other_restarts.py
@@ -30,7 +30,7 @@ from remap_utils import (
 from remap_bin2nc import bin2nc
 
 
-class lake_landice_saltwater(remap_base):
+class other_restarts(remap_base):
     def __init__(self, **configs):
         super().__init__(**configs)
         if self.config["input"]["shared"]["MERRA-2"]:
@@ -572,6 +572,6 @@ endif
 
 
 if __name__ == "__main__":
-    lls = lake_landice_saltwater(params_file="remap_params.yaml")
+    lls = other_restarts(params_file="remap_params.yaml")
     lls.remap()
     lls.remove_geosit()


### PR DESCRIPTION
I think there was a simple rename that was lost in the merge