### PR TITLE
Updates on available MOM6 grids for remapping restart files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Added choices for remapping restart files for o720 (1/2-deg tripolar) and o2880 (1/8-deg tripolar) in MOM6 coupled exps 
+
 ### Added
 
 ### Changed

--- a/pre/remap_restart/remap_utils.py
+++ b/pre/remap_restart/remap_utils.py
@@ -42,7 +42,7 @@ choices_catchmodel = ['catch', 'catchcnclm40', 'catchcnclm51']
 
 choices_ogrid_data = ['360x180   (Reynolds)','1440x720  (MERRA-2)','2880x1440 (OSTIA)','CS  (same as atmosphere OSTIA cubed-sphere grid)']
 
-choices_ogrid_cpld = ['72x36', '360x200', '540x458', '720x410', '1440x1080']
+choices_ogrid_cpld = ['72x36', '360x200', '540x458', '720x410', '720x576', '1440x1080', '2880x2240']
 
 choices_ogrid_cmd  = ['360x180', '1440x720', '2880x1440', 'CS'] + choices_ogrid_cpld
 


### PR DESCRIPTION
## Notes:
- This PR includes updates on remap_restart file for new MOM6 grids at o720(1/2-deg tripolar) and o2880(1/8-deg tripolar).
- This change is employed to choices for the coupled exp.